### PR TITLE
Fix thread synchronization

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -51,6 +51,11 @@ void *collection_main(void *arg) {
     /* Get the current flight state */
 
     err = state_get_flightstate(state, &flight_state); // TODO: error handling
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Could not get flight state: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     /* Collect data; TODO */
 
@@ -59,9 +64,14 @@ void *collection_main(void *arg) {
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     /* Put data in the state structure */
+
     err = state_write_lock(state);
-    if (err)
+    if (err) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+      fprintf(stderr, "Could not acquire state write lock: %d\n", err);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       continue;
+    }
 
     state->data.temp++; // TODO: remove and replace with real data
     state->data.time = ms_since(&start_time); /* Measurement time */
@@ -71,10 +81,18 @@ void *collection_main(void *arg) {
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     err = state_unlock(state);
-    // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Could not release state write lock: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     err = state_signal_change(state);
-    // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Could not signal state change: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     /* Decide whether to move to lift-off state. TODO: real logic */
 
@@ -113,7 +131,7 @@ void *collection_main(void *arg) {
 static uint32_t ms_since(struct timespec *start) {
 
   struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
+  clock_gettime(CLOCK_MONOTONIC, &now); // TODO: this can fail
 
   struct timespec diff = {
       .tv_sec = (now.tv_sec - start->tv_sec),

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -30,6 +30,7 @@ void *logging_main(void *arg) {
   size_t written;
   enum flight_state_e flight_state;
   rocket_state_t *state = ((rocket_state_t *)(arg));
+  uint32_t version = 0;
   char flight_filename[sizeof(CONFIG_INSPACE_TELEMETRY_FLIGHT_FS) +
                        MAX_FILENAME];
   char land_filename[sizeof(CONFIG_INSPACE_TELEMETRY_LANDED_FS) + MAX_FILENAME];
@@ -73,7 +74,7 @@ void *logging_main(void *arg) {
 
       /* Wait for the data to have a change */
 
-      err = state_wait_for_change(state); // TODO: handle error
+      err = state_wait_for_change(state, &version); // TODO: handle error
 
       /* Log data */
 

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -58,6 +58,11 @@ void *logging_main(void *arg) {
   for (;;) {
 
     err = state_get_flightstate(state, &flight_state);
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Error getting flight state: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     switch (flight_state) {
     case STATE_IDLE:
@@ -79,6 +84,11 @@ void *logging_main(void *arg) {
       /* Log data */
 
       err = state_read_lock(state); // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+      if (err) {
+        fprintf(stderr, "Error getting read lock: %d\n", err);
+      }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
       written = fwrite(&state->data, sizeof(state->data), 1, storage);
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
@@ -90,6 +100,11 @@ void *logging_main(void *arg) {
       }
 
       err = state_unlock(state); // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+      if (err) {
+        fprintf(stderr, "Error releasing read lock: %d\n", err);
+      }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
       /* If we are in the idle state, only write the latest n seconds of data
        */
@@ -151,7 +166,7 @@ void *logging_main(void *arg) {
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       }
 
-      state_set_flightstate(state, STATE_IDLE); // TODO: error handling
+      err = state_set_flightstate(state, STATE_IDLE); // TODO: error handling
     }
     }
   }

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -73,22 +73,11 @@ void *logging_main(void *arg) {
 
       /* Wait for the data to have a change */
 
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      printf("Logging thread blocking.\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       err = state_wait_for_change(state); // TODO: handle error
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      printf("Logging thread unblocked.\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
       /* Log data */
 
       err = state_read_lock(state); // TODO: handle error
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      if (err) {
-        fprintf(stderr, "Error getting read lock: %d\n", err);
-      }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
       written = fwrite(&state->data, sizeof(state->data), 1, storage);
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)

--- a/telemetry/src/rocket-state/rocket-state.h
+++ b/telemetry/src/rocket-state/rocket-state.h
@@ -35,8 +35,6 @@ struct rocket_t {
 struct barrier_t {
   pthread_mutex_t lock;  /* Lock for blocking on condvar */
   pthread_cond_t change; /* Condvar to detect state change */
-  uint8_t waiting;       /* Number of threads waiting at the barrier */
-  uint8_t signalled;     /* Number of threads allowed to pass the barrier */
 };
 
 /* A monitor struct for accessing the rocket state safely between threads */

--- a/telemetry/src/rocket-state/rocket-state.h
+++ b/telemetry/src/rocket-state/rocket-state.h
@@ -35,6 +35,7 @@ struct rocket_t {
 struct barrier_t {
   pthread_mutex_t lock;  /* Lock for blocking on condvar */
   pthread_cond_t change; /* Condvar to detect state change */
+  uint32_t version;      /* The version number of the data */
 };
 
 /* A monitor struct for accessing the rocket state safely between threads */
@@ -48,7 +49,7 @@ typedef struct {
 
 int state_init(rocket_state_t *state);
 int state_signal_change(rocket_state_t *state);
-int state_wait_for_change(rocket_state_t *state);
+int state_wait_for_change(rocket_state_t *state, uint32_t *version);
 int state_unlock(rocket_state_t *state);
 int state_read_lock(rocket_state_t *state);
 int state_write_lock(rocket_state_t *state);

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -2,6 +2,7 @@
 #include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "rocket-state/rocket-state.h"
 
@@ -26,7 +27,13 @@ int main(int argc, char **argv) {
 
   /* Initialize shared state */
 
-  state_init(&state);
+  err = state_init(&state);
+  if (err) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Could not initialize state: %d\n", err);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    exit(EXIT_FAILURE);
+  }
 
   /* Start all threads */
 
@@ -47,32 +54,12 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  int policy;
-  struct sched_param param;
-  err = pthread_getschedparam(transmit_thread, &policy, &param);
-
-  err = pthread_setschedparam(transmit_thread, SCHED_FIFO, &param);
-  if (err) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    fprintf(stderr, "Problem setting transmit thread scheduling policy: %d\n",
-            err);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-  }
-
   err = pthread_create(&log_thread, NULL, logging_main, &state);
   if (err) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Problem starting logging thread: %d\n", err);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     exit(EXIT_FAILURE);
-  }
-  err = pthread_setschedparam(log_thread, SCHED_FIFO, &param);
-  if (err) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    fprintf(stderr, "Problem setting logging thread scheduling policy: %d\n",
-            err);
-#endif /* defined                                                              \
-CONFIG_INSPACE_TELEMETRY_DEBUG) */
   }
 
   /* Join on all threads: TODO handle errors */

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -51,13 +51,7 @@ void *transmit_main(void *arg) {
 
   for (;;) {
 
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Transmit thread blocking.\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     err = state_wait_for_change(state); // TODO: handle error
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Transmit thread unblocked.\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     err = state_read_lock(state); // TODO: handle error
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
@@ -93,7 +87,7 @@ void *transmit_main(void *arg) {
     }
     usleep(500000);
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Completed transmission of packet #%lu.\n", seq_num);
+    printf("Completed transmission of packet #%lu of %ld bytes.\n", seq_num, packet_size);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   }
 

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -24,6 +24,7 @@ void *transmit_main(void *arg) {
   int err;
   int radio; /* Radio device file descriptor */
   ssize_t written;
+  uint32_t version = 0;
   rocket_state_t *state = (rocket_state_t *)(arg);
 
   /* Packet variables. */
@@ -51,7 +52,7 @@ void *transmit_main(void *arg) {
 
   for (;;) {
 
-    err = state_wait_for_change(state); // TODO: handle error
+    err = state_wait_for_change(state, &version); // TODO: handle error
 
     err = state_read_lock(state); // TODO: handle error
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
@@ -87,7 +88,8 @@ void *transmit_main(void *arg) {
     }
     usleep(500000);
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Completed transmission of packet #%lu of %ld bytes.\n", seq_num, packet_size);
+    printf("Completed transmission of packet #%lu of %ld bytes.\n", seq_num,
+           packet_size);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   }
 

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -60,11 +60,21 @@ void *transmit_main(void *arg) {
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     err = state_read_lock(state); // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Error acquiring read lock: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     /* Encode radio data into packet. */
 
     packet_size = construct_packet(&state->data, packet, seq_num);
     err = state_unlock(state); // TODO: handle error
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (err) {
+      fprintf(stderr, "Error releasing read lock: %d\n", err);
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
     seq_num++; /* Increment sequence numbering */
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
@@ -75,12 +85,16 @@ void *transmit_main(void *arg) {
 
     written = write(radio, packet, packet_size);
     if (written == -1) {
+      err = errno;
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      fprintf(stderr, "Error transmitting: %d\n", errno);
+      fprintf(stderr, "Error transmitting: %d\n", err);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       // TODO: handle error in errno
     }
     usleep(500000);
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    printf("Completed transmission of packet #%lu.\n", seq_num);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   }
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)


### PR DESCRIPTION
Thread synchronization now works on uniprocessor systems on the basis that each reader tracks the last version of the data it's seen.