### PR TITLE
Use atomics instead of the write lock for flight state

### DIFF
--- a/telemetry/src/rocket-state/rocket-state.h
+++ b/telemetry/src/rocket-state/rocket-state.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdatomic.h>
 
 /* Enum representing the current flight state. */
 
@@ -42,7 +43,7 @@ struct barrier_t {
 
 typedef struct {
   struct rocket_t data;      /* Rocket state data, being protected */
-  enum flight_state_e state; /* Flight state of the rocket. */
+  atomic_int state;          /* Flight state of the rocket. */
   pthread_rwlock_t rw_lock;  /* Read-write lock for modifying state. */
   struct barrier_t barrier;  /* Barrier for synchronizing multiple readers */
 } rocket_state_t;

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <stdatomic.h>
 
 #include "rocket-state/rocket-state.h"
 


### PR DESCRIPTION
We talked about changing the flight state to use POSIX signals at the meeting yesterday, but upon reviewing my idea I have come to the conclusion it sucks. Using a variable for state like we have is fine and probably the best option. An atomic might be a better choice than a mutex though, especially if we go through with not using the state to store data as well. Or we could even just read and write to the state plainly, since it's probably doing exactly that under the hood. 

Let me know what your opinion on this is.