### PR TITLE
Use uORB sensors properly

### DIFF
--- a/mocking/Kconfig
+++ b/mocking/Kconfig
@@ -5,7 +5,7 @@
 
 config INSPACE_MOCKING
 	tristate "Sensor Mocking"
-	depends on BOARDCTL_ROMDISK
+	select BOARDCTL_ROMDISK
 	default n
 	---help---
 		Enable mocking of sensors using test data

--- a/mocking/mocking_main.c
+++ b/mocking/mocking_main.c
@@ -85,6 +85,6 @@ int main(int argc, char **argv) {
     ret = mount_mock_fs();
     if (ret < 0) {
         return ret;
-    } 
+    }
     return register_fakesensors();
 }

--- a/telemetry/Makefile
+++ b/telemetry/Makefile
@@ -16,5 +16,6 @@ CSRCS += $(wildcard src/rocket-state/*.c)
 CSRCS += $(wildcard src/transmission/*.c)
 CSRCS += $(wildcard src/logging/*.c)
 CSRCS += $(wildcard src/packets/*.c)
+CSRCS += $(wildcard src/fusion/*.c)
 
 include $(APPDIR)/Application.mk

--- a/telemetry/Makefile
+++ b/telemetry/Makefile
@@ -17,5 +17,6 @@ CSRCS += $(wildcard src/transmission/*.c)
 CSRCS += $(wildcard src/logging/*.c)
 CSRCS += $(wildcard src/packets/*.c)
 CSRCS += $(wildcard src/fusion/*.c)
+CSRCS += $(wildcard src/sensors/*.c)
 
 include $(APPDIR)/Application.mk

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -5,7 +5,6 @@
 #include <poll.h>
 #include <uORB/uORB.h>
 
-
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
 #include <stdio.h>
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -19,12 +19,14 @@
 #define INTERVAL (1e9 / CONFIG_INSPACE_TELEMETRY_RATE)
 #endif /* CONFIG_INSPACE_TELEMETRY_RATE != 0 */
 
+/* Constants related to sensors */
+
 #define ACCEL_MULTI_BUFFER_SIZE 5
 #define BARO_MULTI_BUFFER_SIZE 5
-
 #define NUM_SENSORS 2
 #define SENSOR_ACCEL 0
 #define SENSOR_BARO 1
+
 static uint32_t ms_since(struct timespec *start);
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -39,6 +39,11 @@ void *collection_main(void *arg) {
   struct timespec start_time;
   rocket_state_t *state = (rocket_state_t *)(arg);
 
+  /* We want collection to get data for the logging & transmission threads 
+   * because sensors (and uorb) only queue data up to the size of the 
+   * sensor's internal buffer. If we set these large could have the same
+   * effect as using buffers but may be less understandable
+   */
   orb_id_t accel_meta = ORB_ID(fusion_accel);
   orb_id_t baro_meta = ORB_ID(fusion_baro);
   struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -11,6 +11,7 @@
 
 #include "../rocket-state/rocket-state.h"
 #include "collection.h"
+#include "../fusion/fusion.h"
 
 /* Measurement interval in nanoseconds */
 
@@ -53,8 +54,8 @@ void *collection_main(void *arg) {
   struct timespec start_time;
   rocket_state_t *state = (rocket_state_t *)(arg);
 
-  orb_id_t accel_meta = orb_get_meta("sensor_accel");
-  orb_id_t baro_meta = orb_get_meta("sensor_baro");
+  orb_id_t accel_meta = ORB_ID(fusion_accel);
+  orb_id_t baro_meta = ORB_ID(fusion_baro);
   struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];
   struct sensor_baro baro_data[BARO_MULTI_BUFFER_SIZE];
 

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -1,0 +1,152 @@
+#include <pthread.h>
+#include <nuttx/sensors/sensor.h>
+#include <sys/ioctl.h>
+#include <poll.h>
+#include <uORB/uORB.h>
+
+
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#include <stdio.h>
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+
+/* UORB debugging help */
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+static void print_orb_state(struct orb_state *state) {
+  if (state == NULL) {
+    printf("State was NULL\n");
+  }
+  else {
+    printf("Maximum Frequency: %d\n", state->max_frequency);
+    printf("Min Batch Interval: %d\n", state->min_batch_interval);
+    printf("Internal Queue Size: %d\n", state->queue_size);
+    printf("Subscribers: %d\n", state->nsubscribers);
+    printf("Generation: %d\n", state->generation);
+  }
+}
+
+/* Format strings for fusioned data, useful for printing debug data using orb_info() */
+static const char fusion_accel_format[] =
+  "fusioned accel - timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";
+static const char fusion_baro_format[] =
+  "timestamp:%" PRIu64 ",pressure:%hf,temperature:%hf";
+
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+
+/* UORB declarations for fused sensor data */
+ORB_DEFINE(fusion_accel, struct sensor_accel);
+ORB_DEFINE(fusion_baro, struct sensor_baro);
+
+/* Input sensors */
+
+#define ACCEL_MULTI_BUFFER_SIZE 5
+#define BARO_MULTI_BUFFER_SIZE 5
+#define NUM_SENSORS 2
+#define SENSOR_ACCEL 0
+#define SENSOR_BARO 1
+
+void *fusion_main(void *arg) {
+  int err;
+
+  /* Input sensors, may want to directly read instead */
+  orb_id_t accel_meta = orb_get_meta("sensor_accel");
+  orb_id_t baro_meta = orb_get_meta("sensor_baro");
+  struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];
+  struct sensor_baro baro_data[BARO_MULTI_BUFFER_SIZE];
+
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+  if (accel_meta == NULL) {
+    fprintf(stderr, "Could not get accel metadata");
+  }
+  if (baro_meta == NULL) {
+    fprintf(stderr, "Could not get baro metadata");
+  }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+
+  struct pollfd input_sensors[NUM_SENSORS];
+  input_sensors[SENSOR_ACCEL].fd = orb_subscribe_multi(accel_meta, 0);
+  input_sensors[SENSOR_ACCEL].events = POLLIN;
+  input_sensors[SENSOR_BARO].fd = orb_subscribe_multi(baro_meta, 0);
+  input_sensors[SENSOR_BARO].events = POLLIN;
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+  if (input_sensors[SENSOR_ACCEL].fd < 0) {
+    fprintf(stderr, "Accel sensor was not opened successfully");
+  }
+  else if (input_sensors[SENSOR_BARO].fd < 0) {
+    fprintf(stderr, "Baro sensor was not opened successfully");
+  }
+  else {
+    struct orb_state orbstate;
+    orb_get_state(input_sensors[SENSOR_ACCEL].fd, &orbstate);
+    printf("Accel sensor state\n");
+    print_orb_state(&orbstate);
+
+    orb_get_state(input_sensors[SENSOR_BARO].fd, &orbstate);
+    printf("Baro sensor state\n");
+    print_orb_state(&orbstate);
+  }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+
+  /* Output sensors */ 
+
+  /* Currently publishing blank data to start, might be better to try and advertise only on first fusioned data */
+  struct sensor_accel output_accel = {.x = 0, .y = 0, .z = 0, .temperature = 0, .timestamp = orb_absolute_time()};
+  struct sensor_baro output_baro = {.pressure = 0, .temperature = 0, .timestamp = orb_absolute_time()};
+  int accel_out = orb_advertise_multi_queue(ORB_ID(fusion_accel), &output_accel, NULL, 1);
+  if (accel_out < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Fusion could not advertise accel topic: %d\n", accel_out);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+  }
+  int baro_out = orb_advertise_multi_queue(ORB_ID(fusion_baro), &output_baro, NULL, 1);
+  if (baro_out < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Fusion could not advertise baro topic: %d\n", baro_out);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+  }
+
+  /* Perform fusion on sensor data endlessly */
+
+  int i = 0;
+  for(;;) {
+    if (i++ % 10 == 0) {
+        printf("sleeping for a second \n");
+        sleep(1);
+    }
+    /* Wait for new data */
+    poll(input_sensors, NUM_SENSORS, -1);
+    if (input_sensors[SENSOR_ACCEL].revents == POLLIN) {
+      int len = orb_copy_multi(input_sensors[SENSOR_ACCEL].fd, accel_data, sizeof(accel_data));
+      if (len < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+        fprintf(stderr, "Error reading from uORB data: %d\n", len);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      }
+      else {
+        for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
+          orb_info(accel_meta->o_format, accel_meta->o_name, &accel_data[i]);
+#endif
+          /* Simply publish the same data we got for now*/
+          orb_publish(ORB_ID(fusion_accel), accel_out, &accel_data[i]);
+        }
+      }
+    }
+    if (input_sensors[SENSOR_BARO].revents == POLLIN) {
+      int len = orb_copy_multi(input_sensors[SENSOR_BARO].fd, baro_data, sizeof(baro_data));
+      if (len < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+        fprintf(stderr, "Error reading from uORB data: %d\n", len);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      }
+      else {
+        for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
+          orb_info(baro_meta->o_format, baro_meta->o_name, &baro_data[i]);
+#endif
+          orb_publish(ORB_ID(fusion_baro), baro_out, &baro_data[i]);
+          /* Do some processing or fusion on this data */
+        }
+      }
+    }
+  }
+}

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -107,14 +107,7 @@ void *fusion_main(void *arg) {
 
   /* Perform fusion on sensor data endlessly */
 
-  int iter = 0;
   for(;;) {
-    iter++;
-    if (iter % 10 == 0) {
-        sleep(1);
-        printf("just slept on read %d\n", iter);
-    }
-    printf("polling for new data from the raw sensors\n");
     /* Wait for new data */
     poll(input_sensors, NUM_SENSORS, -1);
     if (input_sensors[SENSOR_ACCEL].revents == POLLIN) {
@@ -147,7 +140,6 @@ void *fusion_main(void *arg) {
           orb_info(baro_meta->o_format, baro_meta->o_name, &baro_data[i]);
 #endif
           orb_publish(ORB_ID(fusion_baro), baro_out, &baro_data[i]);
-          // TODO - hook this up to logging
           /* Do some processing or fusion on this data */
         }
       }

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -119,9 +119,6 @@ void *fusion_main(void *arg) {
       }
       else {
         for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
-          orb_info(accel_meta->o_format, accel_meta->o_name, &accel_data[i]);
-#endif
           /* Simply publish the same data we got for now*/
           orb_publish(ORB_ID(fusion_accel), accel_out, &accel_data[i]);
         }
@@ -136,9 +133,6 @@ void *fusion_main(void *arg) {
       }
       else {
         for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
-          orb_info(baro_meta->o_format, baro_meta->o_name, &baro_data[i]);
-#endif
           orb_publish(ORB_ID(fusion_baro), baro_out, &baro_data[i]);
           /* Do some processing or fusion on this data */
         }

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -1,36 +1,21 @@
 #include <pthread.h>
 #include <nuttx/sensors/sensor.h>
 #include <sys/ioctl.h>
-#include <poll.h>
-#include <uORB/uORB.h>
 
+#include "../sensors/sensors.h"
 #include "fusion.h"
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
 #include <stdio.h>
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
-/* UORB debugging help */
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-static void print_orb_state(struct orb_state *state) {
-  if (state == NULL) {
-    printf("State was NULL\n");
-  }
-  else {
-    printf("Maximum Frequency: %d\n", state->max_frequency);
-    printf("Min Batch Interval: %d\n", state->min_batch_interval);
-    printf("Internal Queue Size: %d\n", state->queue_size);
-    printf("Subscribers: %d\n", state->nsubscribers);
-    printf("Generation: %d\n", state->generation);
-  }
-}
 
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
 /* Format strings for fusioned data, useful for printing debug data using orb_info() */
 static const char fusion_accel_format[] =
   "fusioned accel - timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";
 static const char fusion_baro_format[] =
   "fusioned baro - timestamp:%" PRIu64 ",pressure:%hf,temperature:%hf";
-
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 /* UORB declarations for fused sensor data */
@@ -42,55 +27,16 @@ ORB_DEFINE(fusion_baro, struct sensor_baro, fusion_baro_format);
 #define ACCEL_MULTI_BUFFER_SIZE 5
 #define BARO_MULTI_BUFFER_SIZE 5
 
-
-struct uorb_inputs {
-  struct pollfd accel;
-  struct pollfd baro;
-};
-#define NUM_SENSORS sizeof(struct uorb_inputs) / sizeof(struct pollfd)
-
 void *fusion_main(void *arg) {
   int err;
 
   /* Input sensors, may want to directly read instead */
-  orb_id_t accel_meta = orb_get_meta("sensor_accel");
-  orb_id_t baro_meta = orb_get_meta("sensor_baro");
+  struct uorb_inputs sensors;
+  clear_uorb_inputs(&sensors);
+  setup_sensor(&sensors.accel, orb_get_meta("sensor_accel"));
+  setup_sensor(&sensors.baro, orb_get_meta("sensor_baro"));
   struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];
   struct sensor_baro baro_data[BARO_MULTI_BUFFER_SIZE];
-
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-  if (accel_meta == NULL) {
-    fprintf(stderr, "Could not get accel metadata");
-  }
-  if (baro_meta == NULL) {
-    fprintf(stderr, "Could not get baro metadata");
-  }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
-  struct uorb_inputs sensors;
-  sensors.accel.fd = orb_subscribe_multi(accel_meta, 0);
-  sensors.accel.events = POLLIN;
-  sensors.baro.fd = orb_subscribe_multi(baro_meta, 0);
-  sensors.baro.events = POLLIN;
-
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-  if (sensors.accel.fd < 0) {
-    fprintf(stderr, "Accel sensor was not opened successfully");
-  }
-  else if (sensors.baro.fd < 0) {
-    fprintf(stderr, "Baro sensor was not opened successfully");
-  }
-  else {
-    struct orb_state orbstate;
-    orb_get_state(sensors.accel.fd, &orbstate);
-    printf("\nAccel sensor state\n");
-    print_orb_state(&orbstate);
-
-    orb_get_state(sensors.baro.fd, &orbstate);
-    printf("\nBaro sensor state\n");
-    print_orb_state(&orbstate);
-  }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
   /* Output sensors */ 
 
@@ -114,33 +60,19 @@ void *fusion_main(void *arg) {
 
   for(;;) {
     /* Wait for new data */
-    poll((struct pollfd *)&sensors, NUM_SENSORS, -1);
-    if (sensors.accel.revents == POLLIN) {
-      int len = orb_copy_multi(sensors.accel.fd, accel_data, sizeof(accel_data));
-      if (len < 0) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-        fprintf(stderr, "Fusion: Error reading from uORB data: %d\n", len);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-      }
-      else {
-        for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
-          /* Simply publish the same data we got for now*/
-          orb_publish(ORB_ID(fusion_accel), accel_out, &accel_data[i]);
-        }
+    poll_sensors(&sensors);
+    int len = get_sensor_data(&sensors.accel, accel_data, sizeof(accel_data));
+    if (len > 0) {
+      for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
+        /* Simply publish the same data we got for now*/
+        orb_publish(ORB_ID(fusion_accel), accel_out, &accel_data[i]);
       }
     }
-    if (sensors.baro.revents == POLLIN) {
-      int len = orb_copy_multi(sensors.baro.fd, baro_data, sizeof(baro_data));
-      if (len < 0) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-        fprintf(stderr, "Fusion: Error reading from uORB data: %d\n", len);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-      }
-      else {
-        for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
-          orb_publish(ORB_ID(fusion_baro), baro_out, &baro_data[i]);
-          /* Do some processing or fusion on this data */
-        }
+    len = get_sensor_data(&sensors.baro, baro_data, sizeof(baro_data));
+    if (len > 0) {
+      for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
+        orb_publish(ORB_ID(fusion_baro), baro_out, &baro_data[i]);
+        /* Do some processing or fusion on this data */
       }
     }
   }

--- a/telemetry/src/fusion/fusion.h
+++ b/telemetry/src/fusion/fusion.h
@@ -1,0 +1,12 @@
+#ifndef _FUSION_H_
+#define _FUSION_H_
+
+#include <uORB/uORB.h>
+
+/* UORB declarations for fused sensor data */
+ORB_DECLARE(fusion_accel);
+ORB_DECLARE(fusion_baro);
+
+#endif // _FUSION_H_
+
+void *fusion_main(void *arg);

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -43,7 +43,7 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
  * Gets data from the sensor if the POLLIN event has occured
  * 
  * @param sensor A pollfd struct with a valid or invalid file descriptor
- * @param data Where to store the data retrieved from the sensor
+ * @param data An array of uORB data structs of the type this sensor uses
  * @param size The size of the data parameter in bytes
  * @return The number of bytes read from the sensor or 0 if there was none to read
  */

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -1,0 +1,65 @@
+#include <poll.h>
+#include "sensors.h"
+
+/**
+ * Set up a pollfd structure for a uORB sensor
+ * 
+ * @param sensor A pollfd struct that will be initialized with a uORB fd and for POLLIN events
+ * @param meta The metadata for the topic the sensor will be subscribed to
+ * @return 0 on success or a negative error code
+ */
+int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
+  if (meta == NULL) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Could not set up sensor, missing metadata\n");
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    return -1;
+  }
+  sensor->fd = orb_subscribe(meta);
+  sensor->events = POLLIN;
+  if (sensor->fd < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Sensor %s was not opened successfully", meta->o_name);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    sensor->events = POLLIN;
+    return sensor->fd;
+  }
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+  else {
+    struct orb_state state;
+    orb_get_state(sensor->fd, &state);
+    printf("Setup successful for sensor %s\n", meta->o_name);
+    printf("Maximum Frequency: %d\n", state.max_frequency);
+    printf("Min Batch Interval: %d\n", state.min_batch_interval);
+    printf("Internal Queue Size: %d\n", state.queue_size);
+    printf("Subscribers: %d\n", state.nsubscribers);
+    printf("Generation: %d\n", state.generation);
+  }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+  return 0;
+}
+
+/**
+ * Gets data from the sensor if the POLLIN event has occured
+ * 
+ * @param sensor A pollfd struct with a valid or invalid file descriptor
+ * @param data Where to store the data retrieved from the sensor
+ * @param size The size of the data parameter in bytes
+ * @return The number of bytes read from the sensor or 0 if there was none to read
+ */
+int get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
+    /*
+     * If the sensor wasn't set up right, POLLIN won't get set, meaning there's no need to avoid using
+     * the sensor if its metadata or fd weren't set up properly
+     */
+    if (sensor->revents == POLLIN) {
+      int len = orb_copy_multi(sensor->fd, data, size);
+      if (len < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+        fprintf(stderr, "Collection: Error reading from uORB data: %d\n", len);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      }
+      return len;
+    }
+    return 0;
+}

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -1,0 +1,43 @@
+#ifndef _INSPACE_SENSORS_H_
+#define _INSPACE_SENSORS_H_
+
+#include <uORB/uORB.h>
+#include <poll.h>
+
+/* Used for polling on multiple sensors at once. Don't set up the ones you don't want to use */
+struct uorb_inputs {
+  struct pollfd accel;
+  struct pollfd baro;
+};
+
+/* The numbers of sensors defined in uorb_inputs */
+#define NUM_SENSORS sizeof(struct uorb_inputs) / sizeof(struct pollfd)
+
+int setup_sensor(struct pollfd *sensor, orb_id_t meta);
+int get_sensor_data(struct pollfd *sensor, void *data, size_t size);
+
+/**
+ * Clears the uorb_inputs struct to make no sensors get polled on accidentally. After this,
+ * should be fine to only set up a the desired sensors and poll everything
+ * 
+ * @param sensors The uorb_inputs struct to clear
+ */
+static void clear_uorb_inputs(struct uorb_inputs *sensors) {
+  struct pollfd *sensor_array = (struct pollfd *)sensors;
+  for (int i = 0; i < NUM_SENSORS; i++) {
+    sensor_array[i].fd = -1;
+    sensor_array[i].events = 0;
+  }
+}
+
+/**
+ * Polls on all sensors in the uorb_inputs struct
+ * 
+ * @param sensors The uorb_inputs struct to poll on
+ */
+static void poll_sensors(struct uorb_inputs *sensors) {
+    poll((struct pollfd *)sensors, NUM_SENSORS, -1);
+}
+
+#endif // _INSPACE_SENSORS_H_
+

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -10,6 +10,7 @@
 #include "collection/collection.h"
 #include "logging/logging.h"
 #include "transmission/transmit.h"
+#include "fusion/fusion.h"
 
 int main(int argc, char **argv) {
 
@@ -21,6 +22,7 @@ int main(int argc, char **argv) {
   pthread_t transmit_thread;
   pthread_t log_thread;
   pthread_t collect_thread;
+  pthread_t fusion_thread;
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
   puts("You are running the Carleton University InSpace telemetry system.");
@@ -63,11 +65,20 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
+  err = pthread_create(&fusion_thread, NULL, fusion_main, &state);
+  if (err) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Problem starting fusion thread: %d\n", err);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    exit(EXIT_FAILURE);
+  }
+
   /* Join on all threads: TODO handle errors */
 
   err = pthread_join(collect_thread, NULL);
   err = pthread_join(transmit_thread, NULL);
   err = pthread_join(log_thread, NULL);
+  err = pthread_join(fusion_thread, NULL);
 
   return err;
 }


### PR DESCRIPTION
- Added a sensor fusion thread that will read data and then publish it to the system again (without any modification right now). This could be moved into collection or collection might be able to be removed if it's responsibility of updating the flight state isn't important enough to separate from everything else. Right now things are set up so the data is republished by the fusion thread and then printed by the collection thread, just to show how uORB works
- Replaced existing uORB code with the actual uORB style of doing things
- Added a sensors folder containing common code to setting up and using uORB sensors that will be useful for any thread using uORB sensors

There's still some work to be done to get the uORB data to be logged or transmitted without using the flight state structure.
