### PR TITLE
Use uORB for logging and transmission

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -18,10 +18,6 @@
 #define INTERVAL (1e9 / CONFIG_INSPACE_TELEMETRY_RATE)
 #endif /* CONFIG_INSPACE_TELEMETRY_RATE != 0 */
 
-/* Sizes of buffers for getting new data from uORB */
-#define ACCEL_MULTI_BUFFER_SIZE 1
-#define BARO_MULTI_BUFFER_SIZE 1
-
 static uint32_t ms_since(struct timespec *start);
 static void update_state(rocket_state_t *state, struct sensor_baro *baro_data);
 
@@ -39,8 +35,8 @@ void *collection_main(void *arg) {
   clear_uorb_inputs(&sensors);
   setup_sensor(&sensors.accel, ORB_ID(fusion_accel));
   setup_sensor(&sensors.baro, ORB_ID(fusion_baro));
-  struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];
-  struct sensor_baro baro_data[BARO_MULTI_BUFFER_SIZE];
+  struct sensor_accel accel_data[ACCEL_FUSION_BUFFER_SIZE];
+  struct sensor_baro baro_data[BARO_FUSION_BUFFER_SIZE];
 
 #if CONFIG_INSPACE_TELEMETRY_RATE != 0
   struct timespec period_start;

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -82,9 +82,8 @@ void *collection_main(void *arg) {
       for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
         struct orb_metadata *meta = ORB_ID(fusion_accel);
-        orb_info(meta->o_format, meta->o_name, &accel_data[i]);
+        /*orb_info(meta->o_format, meta->o_name, &accel_data[i]);*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-        update_state(state, &accel_data[i]);
       }
     } 
     len = get_sensor_data(&sensors.baro, baro_data, sizeof(baro_data));
@@ -92,7 +91,7 @@ void *collection_main(void *arg) {
       for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
         struct orb_metadata *meta = ORB_ID(fusion_baro);
-        orb_info(meta->o_format, meta->o_name, &baro_data[i]);
+        /*orb_info(meta->o_format, meta->o_name, &baro_data[i]);*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       }
     }
@@ -147,37 +146,4 @@ static uint32_t ms_since(struct timespec *start) {
   }
 
   return diff.tv_sec * 1000 + (diff.tv_nsec / 1e6);
-}
-
-
-static void update_state(rocket_state_t *state, struct sensor_baro *baro_data) {
-    /* Put data in the state structure */
-    int err = state_write_lock(state);
-    if (err) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      fprintf(stderr, "Could not acquire state write lock: %d\n", err);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-      return;
-    }
-
-    state->data.temp = baro_data->temperature * 1000; /* Convert to millidegrees */
-    state->data.time = baro_data->timestamp; /* Measurement time */
-
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Measurement time: %lu ms\n", state->data.time);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
-    err = state_unlock(state);
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    if (err) {
-      fprintf(stderr, "Could not release state write lock: %d\n", err);
-    }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
-    err = state_signal_change(state);
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    if (err) {
-      fprintf(stderr, "Could not signal state change: %d\n", err);
-    }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 }

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -19,7 +19,6 @@
 #endif /* CONFIG_INSPACE_TELEMETRY_RATE != 0 */
 
 static uint32_t ms_since(struct timespec *start);
-static void update_state(rocket_state_t *state, struct sensor_baro *baro_data);
 
 /*
  * Collection thread which runs to collect data.
@@ -70,19 +69,14 @@ void *collection_main(void *arg) {
     }
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
-
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Collecting data...\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
     /* Wait for new data */
     poll_sensors(&sensors);
     int len = get_sensor_data(&sensors.accel, accel_data, sizeof(accel_data));
     if (len > 0) {
       for (int i = 0; i < (len / sizeof(struct sensor_accel)); i++) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
-        struct orb_metadata *meta = ORB_ID(fusion_accel);
-        /*orb_info(meta->o_format, meta->o_name, &accel_data[i]);*/
+        /*const struct orb_metadata *meta = ORB_ID(fusion_accel);
+        orb_info(meta->o_format, meta->o_name, &accel_data[i]);*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       }
     } 
@@ -90,8 +84,8 @@ void *collection_main(void *arg) {
     if (len > 0) {
       for (int i = 0; i < (len / sizeof(struct sensor_baro)); i++) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG) && defined(CONFIG_DEBUG_UORB)
-        struct orb_metadata *meta = ORB_ID(fusion_baro);
-        /*orb_info(meta->o_format, meta->o_name, &baro_data[i]);*/
+        /*const struct orb_metadata *meta = ORB_ID(fusion_baro);
+        orb_info(meta->o_format, meta->o_name, &baro_data[i]);*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       }
     }

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -28,8 +28,6 @@ ORB_DEFINE(fusion_baro, struct sensor_baro, fusion_baro_format);
 
 
 void *fusion_main(void *arg) {
-  int err;
-
   /* Input sensors, may want to directly read instead */
   struct uorb_inputs sensors;
   clear_uorb_inputs(&sensors);

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -22,10 +22,10 @@ static const char fusion_baro_format[] =
 ORB_DEFINE(fusion_accel, struct sensor_accel, fusion_accel_format);
 ORB_DEFINE(fusion_baro, struct sensor_baro, fusion_baro_format);
 
-/* Input sensors */
+/* Buffers for inputs, best to match to the size of the internal sensor buffers */
+#define ACCEL_INPUT_BUFFER_SIZE 5
+#define BARO_INPUT_BUFFER_SIZE 5
 
-#define ACCEL_MULTI_BUFFER_SIZE 5
-#define BARO_MULTI_BUFFER_SIZE 5
 
 void *fusion_main(void *arg) {
   int err;
@@ -35,21 +35,21 @@ void *fusion_main(void *arg) {
   clear_uorb_inputs(&sensors);
   setup_sensor(&sensors.accel, orb_get_meta("sensor_accel"));
   setup_sensor(&sensors.baro, orb_get_meta("sensor_baro"));
-  struct sensor_accel accel_data[ACCEL_MULTI_BUFFER_SIZE];
-  struct sensor_baro baro_data[BARO_MULTI_BUFFER_SIZE];
+  struct sensor_accel accel_data[ACCEL_INPUT_BUFFER_SIZE];
+  struct sensor_baro baro_data[BARO_INPUT_BUFFER_SIZE];
 
   /* Output sensors */ 
 
   /* Currently publishing blank data to start, might be better to try and advertise only on first fusioned data */
   struct sensor_accel output_accel = {.x = 0, .y = 0, .z = 0, .temperature = 0, .timestamp = orb_absolute_time()};
   struct sensor_baro output_baro = {.pressure = 0, .temperature = 0, .timestamp = orb_absolute_time()};
-  int accel_out = orb_advertise_multi_queue(ORB_ID(fusion_accel), &output_accel, NULL, 1);
+  int accel_out = orb_advertise_multi_queue(ORB_ID(fusion_accel), &output_accel, NULL, ACCEL_FUSION_BUFFER_SIZE);
   if (accel_out < 0) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Fusion could not advertise accel topic: %d\n", accel_out);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   }
-  int baro_out = orb_advertise_multi_queue(ORB_ID(fusion_baro), &output_baro, NULL, 1);
+  int baro_out = orb_advertise_multi_queue(ORB_ID(fusion_baro), &output_baro, NULL, BARO_FUSION_BUFFER_SIZE);
   if (baro_out < 0) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Fusion could not advertise baro topic: %d\n", baro_out);

--- a/telemetry/src/fusion/fusion.h
+++ b/telemetry/src/fusion/fusion.h
@@ -7,6 +7,13 @@
 ORB_DECLARE(fusion_accel);
 ORB_DECLARE(fusion_baro);
 
+/* 
+ * Size of the internal queues for the fusioned data, which other threads should 
+ * match the size of their buffers to 
+ */
+#define ACCEL_FUSION_BUFFER_SIZE 100
+#define BARO_FUSION_BUFFER_SIZE 100
+
 #endif // _FUSION_H_
 
 void *fusion_main(void *arg);

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 
 #include "logging.h"
+#include "../fusion/fusion.h"
+#include "../sensors/sensors.h"
+#include "../packets/packets.h"
 
 /* The maximum size of a log file's file name. */
 
@@ -21,6 +24,12 @@
 
 #define err_to_ptr(err) ((void *)((err)))
 
+static size_t log(FILE *storage, uint8_t *packet, size_t packet_size);
+static uint8_t *create_block(FILE *storage, uint8_t *packet, uint8_t *block, uint32_t *seq_num, enum block_type_e type, uint32_t mission_time);
+static uint32_t us_to_ms(uint64_t us) {
+  return (uint32_t)(us / 1000);
+}
+
 /*
  * Logging thread which runs to log data to the SD card.
  */
@@ -34,6 +43,13 @@ void *logging_main(void *arg) {
   char flight_filename[sizeof(CONFIG_INSPACE_TELEMETRY_FLIGHT_FS) +
                        MAX_FILENAME];
   char land_filename[sizeof(CONFIG_INSPACE_TELEMETRY_LANDED_FS) + MAX_FILENAME];
+
+  /* Use packets for the logging format to stay consistent */
+
+  uint8_t packet[PACKET_MAX_SIZE];     /* Array of bytes for packet */
+  uint8_t *current_block = packet;     /* Location in packet buffer */
+  uint8_t *next_block;                 /* Next block in packet buffer */
+  uint32_t seq_num = 0;                /* Packet numbering */
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
   printf("Logging thread started.\n");
@@ -54,6 +70,13 @@ void *logging_main(void *arg) {
     pthread_exit(err_to_ptr(err)); // TODO: fail more gracefully
   }
 
+  struct uorb_inputs sensors;
+  clear_uorb_inputs(&sensors);
+  setup_sensor(&sensors.accel, ORB_ID(fusion_accel));
+  setup_sensor(&sensors.baro, ORB_ID(fusion_baro));
+  struct sensor_accel accel_data[ACCEL_FUSION_BUFFER_SIZE];
+  struct sensor_baro baro_data[BARO_FUSION_BUFFER_SIZE];
+
   /* Infinite loop to handle states */
 
   for (;;) {
@@ -70,32 +93,31 @@ void *logging_main(void *arg) {
       /* Purposeful fall-through */
     case STATE_AIRBORNE: {
 
-      /* Infinite loop to log data */
+      /* Wait for new data */
+      poll_sensors(&sensors);
+      // Get data together, so we can block on transmit and not lose the data we're currently using
+      // Could also ask for the minimum of the free space in the size of the buffer to save effort
+      ssize_t accel_len = get_sensor_data(&sensors.accel, accel_data, sizeof(accel_data));
+      ssize_t baro_len = get_sensor_data(&sensors.baro, baro_data, sizeof(baro_data));
 
-      /* Wait for the data to have a change */
-
-      err = state_wait_for_change(state, &version); // TODO: handle error
-
-      /* Log data */
-
-      err = state_read_lock(state); // TODO: handle error
-
-      written = fwrite(&state->data, sizeof(state->data), 1, storage);
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      printf("Logged %u bytes\n", written * sizeof(state->data));
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-      if (written == 0) {
-        // TODO: Handle error (might happen if file got too large, start
-        // another file)
+      if (accel_len > 0) {
+        for (int i = 0; i < (accel_len / sizeof(struct sensor_accel)); i++) {
+          next_block = create_block(storage, packet, current_block, &seq_num, DATA_ACCEL_ABS, us_to_ms(accel_data[i].timestamp));
+          accel_blk_init((struct accel_blk_t*)block_body(current_block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
+          current_block = next_block;
+        }
       }
+      if (baro_len > 0) {
+        for (int i = 0; i < (baro_len / sizeof(struct sensor_baro)); i++) {
+          next_block = create_block(storage, packet, current_block, &seq_num, DATA_PRESSURE, us_to_ms(baro_data[i].timestamp));
+          pres_blk_init((struct pres_blk_t*)block_body(current_block), baro_data[i].pressure);
+          current_block = next_block;
 
-      err = state_unlock(state); // TODO: handle error
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      if (err) {
-        fprintf(stderr, "Error releasing read lock: %d\n", err);
+          next_block = create_block(storage, packet, current_block, &seq_num, DATA_TEMP, us_to_ms(baro_data[i].timestamp));
+          temp_blk_init((struct temp_blk_t*)block_body(current_block), baro_data[i].temperature);
+          current_block = next_block;
+        }
       }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
       /* If we are in the idle state, only write the latest n seconds of data
        */
       if (flight_state == STATE_IDLE) {
@@ -170,4 +192,45 @@ void *logging_main(void *arg) {
   fclose(storage);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   pthread_exit(err_to_ptr(err));
+}
+
+/**
+ * Create a block and set it up, or transmit and make a new packet if a block can't be added
+ *
+ * @param radio The radio to write the packet to when full
+ * @param packet The packet to write to
+ * @param block The block to create and initialize the header and time for
+ * @param seq_num The current sequence number, incremented if a packet is transmitted
+ * @param type The type of block to add
+ * @param mission_time If the type of block requires a time, the time to use
+ * @return The start of the next block
+ */
+static uint8_t *create_block(FILE *storage, uint8_t *packet, uint8_t *block, uint32_t *seq_num, enum block_type_e type, uint32_t mission_time) {
+  uint8_t *next_block = pkt_create_blk(packet, block, type, mission_time);
+  if (next_block == NULL) {
+    if (block != packet) {
+      log(storage, packet, block - packet);
+      *seq_num += 1;
+    }
+    // We can delay setting up the header and just let the addition of the first block fail
+    block = init_pkt(packet, *seq_num, mission_time);
+    next_block = pkt_create_blk(packet, block, type, mission_time);
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    if (next_block == NULL) {
+      fprintf(stderr, "Error adding block to packet after transmission, should not be possible\n");
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+  }
+  return next_block;
+}
+
+static size_t log(FILE *storage, uint8_t *packet, size_t packet_size) {
+      size_t written = fwrite(packet, 1, packet_size, storage);
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+      printf("Logged %u bytes\n", written);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      if (written == 0) {
+        // TODO: Handle error (might happen if file got too large, start
+        // another file)
+      }
 }

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -103,6 +103,26 @@ size_t blk_len(enum block_type_e type) {
   }
 }
 
+/* Initialize a packet with a header and return a pointer to the first byte of its body
+ * @param packet The packet to initialize
+ * @param packet_num The sequence number of the packet
+ * @param mission_time The mission time of the packet
+ * @returns A pointer to the first byte of the packet body
+ */
+uint8_t *init_pkt(uint8_t *packet, uint8_t packet_num, uint32_t mission_time) {
+  pkt_hdr_t *header = (pkt_hdr_t *)packet;
+  pkt_hdr_init(header, packet_num, mission_time);
+  return packet + sizeof(header);
+}
+
+/*
+ * Creates a block in a packet if it is possible to do so
+ * @param packet The packet to add the block to
+ * @param write_pointer The current write location in the packet
+ * @param type The type of block to add
+ * @param mission_time The measurement time of the block will be created
+ * @return A pointer to the block that was created, or NULL if a packet cannot be added
+ */
 uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type_e type, uint32_t mission_time) {
   pkt_hdr_t *header = (pkt_hdr_t *)packet;
   size_t packet_size = packet - write_pointer;
@@ -120,7 +140,7 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type
     if (!calc_offset(mission_time, header->timestamp, &((offset_blk *)block_body)->time_offset)) {
       return NULL;
     }
-  } 
+  }
   write_pointer += block_size;
   return block;
 }
@@ -142,6 +162,15 @@ void alt_blk_init(struct alt_blk_t *b, const int32_t altitude) {
  */
 void temp_blk_init(struct temp_blk_t *b, const int32_t temperature) {
   b->temperature = temperature;
+}
+
+/*
+ * Construct a pressure block
+ * @param b The pressure block to initialize
+ * @param pressure The pressure measured in Pascals
+ */
+void pres_blk_init(struct pres_blk_t *b, const int32_t pressure) {
+  b->pressure = pressure;
 }
 
 /*

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -158,6 +158,7 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type,
       return NULL;
     }
   }
+  blk_hdr_init((blk_hdr_t *)block, type);
   return block + block_size;
 }
 

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -131,7 +131,7 @@ uint8_t *block_body(uint8_t *block) {
  * @param block Where to add the block, if one were able to be added
  * @param type The type of block to add
  * @param mission_time If the block type has an offset, set the offset using this time
- * @returns The location to add the next block, or NULL if the block could not be added
+ * @returns The location to add the next block, or NULL if the block can not be added
  */
 uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type, uint32_t mission_time) {
   pkt_hdr_t *header = (pkt_hdr_t *)packet;

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -1,8 +1,10 @@
 #include <string.h>
 
-#include <stdio.h>
-
 #include "packets.h"
+
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#include <stdio.h>
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 /* Get the absolute timestamp that should be used for a packet created
  * at the given mission time
@@ -33,10 +35,6 @@ static int calc_offset(uint32_t mission_time, uint16_t abs_timestamp,
     return 0;
   }
   return 1;
-}
-
-static uint32_t expand_abs_timestamp(uint16_t abs_timestamp) {
-  return abs_timestamp * 30 * 1000;
 }
 
 /* Check if a block has an offset that needs to be set
@@ -73,7 +71,7 @@ void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type) {
   b->type = type;
 }
 
-/* Return the length of a block of this type's body, excluding the header
+/* Return the length of a block of this type's body
  * @param type The type of block to get the length of
  * @return The number of bytes in the block body
  */
@@ -140,20 +138,20 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type,
 
   if (packet_size < sizeof(pkt_hdr_t)) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    fprintf(stderr, "Packet is too small to contain a header\n");
+    /*fprintf(stderr, "Packet is too small to contain a header\n");*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     return NULL;
   }
   if ((packet_size + block_size) > PACKET_MAX_SIZE) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    fprintf(stderr, "Packet is too large to contain another block, packet size is %d, block size is %d\n", packet_size, block_size);
+    /*fprintf(stderr, "Packet is too large to contain another block, packet size is %d, block size is %d\n", packet_size, block_size);*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     return NULL;
   }
   if (has_offset(type)) {
     if (calc_offset(mission_time, header->timestamp, &((offset_blk *)block_body(block))->time_offset)) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      fprintf(stderr, "Could not fit time into packet, time was %d and packet header had %d\n", mission_time, expand_abs_timestamp(header->timestamp));
+      /*fprintf(stderr, "Could not fit time into packet, time was %d and packet header had %d\n", mission_time, 30000 * header->timestamp );*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       return NULL;
     }

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -62,7 +62,7 @@ typedef struct {
 
 void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
-int blk_len(blk_hdr_t *b);
+size_t blk_len(enum block_type_e type);
 
 uint8_t *init_pkt(uint8_t *packet, uint8_t packet_num, uint32_t mission_time);
 uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type_e type, uint32_t mission_time);

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -64,6 +64,7 @@ void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
 int blk_len(blk_hdr_t *b);
 
+uint8_t *init_pkt(uint8_t *packet, uint8_t packet_num, uint32_t mission_time);
 uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type_e type, uint32_t mission_time);
 
 /* A data block containing information about altitude. */

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -57,6 +57,7 @@ typedef struct {
 
 /* Base type for blocks with a time offset */
 typedef struct {
+  /* The offset from the absolute time in the header in milliseconds */
   int16_t time_offset;
 } offset_blk;
 
@@ -66,7 +67,7 @@ size_t blk_body_len(enum block_type_e type);
 
 uint8_t *block_body(uint8_t *block);
 uint8_t *init_pkt(uint8_t *packet, uint8_t packet_num, uint32_t mission_time);
-uint8_t *pkt_create_blk(uint8_t *packet, uint8_t **write_pointer, enum block_type_e type, uint32_t mission_time);
+uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type, uint32_t mission_time);
 
 /* A data block containing information about altitude. */
 struct alt_blk_t {

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -64,7 +64,7 @@ void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
 int blk_len(blk_hdr_t *b);
 
-int pkt_add_blk(uint8_t *packet, uint8_t len, blk_hdr_t *b_header, uint8_t *b_body, uint32_t mission_time);
+uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type_e type, uint32_t mission_time);
 
 /* A data block containing information about altitude. */
 struct alt_blk_t {

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -64,7 +64,7 @@ void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
 int blk_len(blk_hdr_t *b);
 
-int pkt_add_blk(pkt_hdr_t *p, blk_hdr_t *b, void *blk, uint32_t mission_time);
+int pkt_add_blk(uint8_t *packet, uint8_t len, blk_hdr_t *b_header, uint8_t *b_body, uint32_t mission_time);
 
 /* A data block containing information about altitude. */
 struct alt_blk_t {

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -62,10 +62,11 @@ typedef struct {
 
 void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
-size_t blk_len(enum block_type_e type);
+size_t blk_body_len(enum block_type_e type);
 
+uint8_t *block_body(uint8_t *block);
 uint8_t *init_pkt(uint8_t *packet, uint8_t packet_num, uint32_t mission_time);
-uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *write_pointer, enum block_type_e type, uint32_t mission_time);
+uint8_t *pkt_create_blk(uint8_t *packet, uint8_t **write_pointer, enum block_type_e type, uint32_t mission_time);
 
 /* A data block containing information about altitude. */
 struct alt_blk_t {

--- a/telemetry/src/rocket-state/rocket-state.c
+++ b/telemetry/src/rocket-state/rocket-state.c
@@ -22,82 +22,6 @@ static enum flight_state_e get_flight_state(void) {
   return STATE_IDLE;
 }
 
-/* Initialize the barrier object.
- * @param barrier A reference to the barrier to initialize.
- * @return 0 on success, error code on failure.
- */
-static int barrier_init(struct barrier_t *barrier) {
-  int err;
-  barrier->version = 0;
-  err = pthread_mutex_init(&barrier->lock, NULL);
-  if (err)
-    return err;
-  return pthread_cond_init(&barrier->change, NULL);
-}
-
-/* Unblock all threads currently waiting on the barrier.
- * @param barrier The barrier to broadcast on
- * @return 0 for success, error code on failure
- */
-static int barrier_signal_change(struct barrier_t *barrier) {
-
-  int err;
-
-  /* Increment the version number of the data. */
-
-  err = pthread_mutex_lock(&barrier->lock);
-  if (err)
-    return err;
-
-  barrier->version++;
-
-  err = pthread_mutex_unlock(&barrier->lock);
-  if (err)
-    return err;
-
-    /* Allow all currently waiting threads to pass */
-
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-  printf("State change signalled.\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
-  return pthread_cond_broadcast(&barrier->change);
-}
-
-/* Block on the barrier until a change is signalled.
- * @param barrier The barrier to block on.
- * @param version The last version of data the caller has seen
- * @return 0 for success, error code on failure.
- */
-static int barrier_wait_for_change(struct barrier_t *barrier,
-                                   uint32_t *version) {
-
-  int err;
-
-  /* Lock mutex for wait_blocking */
-
-  err = pthread_mutex_lock(&barrier->lock);
-  if (err)
-    return err;
-
-  /*
-   * If the latest version of the data matches is less than or equal to the last
-   * version we saw, we should block and wait for something new that we haven't
-   * seen before.
-   */
-
-  while (barrier->version <= *version) {
-    pthread_cond_wait(&barrier->change, &barrier->lock);
-  }
-
-  /* If we are here, the state has changed and we have passed the barrier.
-   * Make sure we update our most recently seen version, then release the lock
-   * so we can do something with the newly changed state.
-   */
-
-  *version = barrier->version;
-  return pthread_mutex_unlock(&barrier->lock);
-}
 
 /* Initialize the rocket state monitor
  * @param state The rocket state to initialize
@@ -105,58 +29,8 @@ static int barrier_wait_for_change(struct barrier_t *barrier,
  * @return 0 on success, error code on failure
  */
 int state_init(rocket_state_t *state) {
-
-  int err;
-
   atomic_store(&state->state, get_flight_state());
-
-  err = barrier_init(&state->barrier);
-  if (err)
-    return err;
-
-  err = pthread_rwlock_init(&state->rw_lock, NULL);
-  return err;
-}
-
-/* Signal that the rocket state has changed to all waiting threads.
- * @param state The rocket state for which to broadcast a change
- * @return 0 on success, error code on failure
- */
-int state_signal_change(rocket_state_t *state) {
-  return barrier_signal_change(&state->barrier);
-}
-
-/* Blocking wait until the rocket state has changed.
- * @param state The rocket state on which to wait for a change
- * @param version The last version of the data seen by the caller
- * @return 0 on success, error code on failure
- */
-int state_wait_for_change(rocket_state_t *state, uint32_t *version) {
-  return barrier_wait_for_change(&state->barrier, version);
-}
-
-/* Lock the rocket state for writing.
- * @param state The rocket state to lock
- * @return 0 on success, error code on failure
- */
-int state_write_lock(rocket_state_t *state) {
-  return pthread_rwlock_wrlock(&state->rw_lock);
-}
-
-/* Lock the rocket state for reading.
- * @param state The rocket state to lock
- * @return 0 on success, error code on failure
- */
-int state_read_lock(rocket_state_t *state) {
-  return pthread_rwlock_rdlock(&state->rw_lock);
-}
-
-/* Unlock the rocket state from reading or writing.
- * @param state The rocket state to unlock
- * @return 0 on success, error code on failure
- */
-int state_unlock(rocket_state_t *state) {
-  return pthread_rwlock_unlock(&state->rw_lock);
+  return 0;
 }
 
 /*

--- a/telemetry/src/rocket-state/rocket-state.h
+++ b/telemetry/src/rocket-state/rocket-state.h
@@ -14,46 +14,11 @@ enum flight_state_e {
   STATE_LANDED,   /* Rocket is landed. */
 };
 
-/* GPS coordinates */
-
-struct coordinate_t {
-  int32_t lat; /* Latitude in microdegrees */
-  int32_t lon; /* Longitude in microdegrees */
-};
-
-/* Describes the state of the rocket at any given moment */
-
-struct rocket_t {
-  uint32_t time;    /* Time of measurement in milliseconds since launch */
-  int32_t temp;     /* Temperature in millidegrees Celsius */
-  int32_t pressure; /* Pressure in Pascals */
-  int32_t altitude; /* Altitude in millimetres */
-  struct coordinate_t coords;
-};
-
-/* A barrier for stopping threads */
-
-struct barrier_t {
-  pthread_mutex_t lock;  /* Lock for blocking on condvar */
-  pthread_cond_t change; /* Condvar to detect state change */
-  uint32_t version;      /* The version number of the data */
-};
-
-/* A monitor struct for accessing the rocket state safely between threads */
-
 typedef struct {
-  struct rocket_t data;      /* Rocket state data, being protected */
   atomic_int state;          /* Flight state of the rocket. */
-  pthread_rwlock_t rw_lock;  /* Read-write lock for modifying state. */
-  struct barrier_t barrier;  /* Barrier for synchronizing multiple readers */
 } rocket_state_t;
 
 int state_init(rocket_state_t *state);
-int state_signal_change(rocket_state_t *state);
-int state_wait_for_change(rocket_state_t *state, uint32_t *version);
-int state_unlock(rocket_state_t *state);
-int state_read_lock(rocket_state_t *state);
-int state_write_lock(rocket_state_t *state);
 int state_set_flightstate(rocket_state_t *state,
                           enum flight_state_e flight_state);
 int state_get_flightstate(rocket_state_t *state,

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -3,7 +3,7 @@
 
 /**
  * Set up a pollfd structure for a uORB sensor
- * 
+ *
  * @param sensor A pollfd struct that will be initialized with a uORB fd and for POLLIN events
  * @param meta The metadata for the topic the sensor will be subscribed to
  * @return 0 on success or a negative error code
@@ -41,7 +41,7 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
 
 /**
  * Gets data from the sensor if the POLLIN event has occured
- * 
+ *
  * @param sensor A pollfd struct with a valid or invalid file descriptor
  * @param data An array of uORB data structs of the type this sensor uses
  * @param size The size of the data parameter in bytes

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -58,10 +58,33 @@ ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
       ssize_t len = orb_copy_multi(sensor->fd, data, size);
       if (len < 0) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-        fprintf(stderr, "Collection: Error reading from uORB data: %d\n", len);
+        fprintf(stderr, "Collection: Error reading from uORB data: %ld\n", len);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
       }
       return len;
     }
     return 0;
+}
+
+/**
+ * Clears the uorb_inputs struct to make no sensors get polled on accidentally. After this,
+ * should be fine to only set up a the desired sensors and poll everything
+ *
+ * @param sensors The uorb_inputs struct to clear
+ */
+void clear_uorb_inputs(struct uorb_inputs *sensors) {
+  struct pollfd *sensor_array = (struct pollfd *)sensors;
+  for (int i = 0; i < NUM_SENSORS; i++) {
+    sensor_array[i].fd = -1;
+    sensor_array[i].events = 0;
+  }
+}
+
+/**
+ * Polls on all sensors in the uorb_inputs struct
+ *
+ * @param sensors The uorb_inputs struct to poll on
+ */
+void poll_sensors(struct uorb_inputs *sensors) {
+    poll((struct pollfd *)sensors, NUM_SENSORS, -1);
 }

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -29,11 +29,13 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
     struct orb_state state;
     orb_get_state(sensor->fd, &state);
     printf("Setup successful for sensor %s\n", meta->o_name);
+    /* Not always useful
     printf("Maximum Frequency: %d\n", state.max_frequency);
     printf("Min Batch Interval: %d\n", state.min_batch_interval);
     printf("Internal Queue Size: %d\n", state.queue_size);
     printf("Subscribers: %d\n", state.nsubscribers);
     printf("Generation: %d\n", state.generation);
+    */
   }
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   return 0;

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -47,13 +47,13 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
  * @param size The size of the data parameter in bytes
  * @return The number of bytes read from the sensor or 0 if there was none to read
  */
-int get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
+ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
     /*
      * If the sensor wasn't set up right, POLLIN won't get set, meaning there's no need to avoid using
      * the sensor if its metadata or fd weren't set up properly
      */
     if (sensor->revents == POLLIN) {
-      int len = orb_copy_multi(sensor->fd, data, size);
+      ssize_t len = orb_copy_multi(sensor->fd, data, size);
       if (len < 0) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
         fprintf(stderr, "Collection: Error reading from uORB data: %d\n", len);

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -14,12 +14,12 @@ struct uorb_inputs {
 #define NUM_SENSORS sizeof(struct uorb_inputs) / sizeof(struct pollfd)
 
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
-int get_sensor_data(struct pollfd *sensor, void *data, size_t size);
+ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
 
 /**
  * Clears the uorb_inputs struct to make no sensors get polled on accidentally. After this,
  * should be fine to only set up a the desired sensors and poll everything
- * 
+ *
  * @param sensors The uorb_inputs struct to clear
  */
 static void clear_uorb_inputs(struct uorb_inputs *sensors) {
@@ -32,7 +32,7 @@ static void clear_uorb_inputs(struct uorb_inputs *sensors) {
 
 /**
  * Polls on all sensors in the uorb_inputs struct
- * 
+ *
  * @param sensors The uorb_inputs struct to poll on
  */
 static void poll_sensors(struct uorb_inputs *sensors) {

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -15,29 +15,8 @@ struct uorb_inputs {
 
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
 ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
-
-/**
- * Clears the uorb_inputs struct to make no sensors get polled on accidentally. After this,
- * should be fine to only set up a the desired sensors and poll everything
- *
- * @param sensors The uorb_inputs struct to clear
- */
-static void clear_uorb_inputs(struct uorb_inputs *sensors) {
-  struct pollfd *sensor_array = (struct pollfd *)sensors;
-  for (int i = 0; i < NUM_SENSORS; i++) {
-    sensor_array[i].fd = -1;
-    sensor_array[i].events = 0;
-  }
-}
-
-/**
- * Polls on all sensors in the uorb_inputs struct
- *
- * @param sensors The uorb_inputs struct to poll on
- */
-static void poll_sensors(struct uorb_inputs *sensors) {
-    poll((struct pollfd *)sensors, NUM_SENSORS, -1);
-}
+void clear_uorb_inputs(struct uorb_inputs *sensors);
+void poll_sensors(struct uorb_inputs *sensors);
 
 #endif // _INSPACE_SENSORS_H_
 

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -28,8 +28,6 @@ void *transmit_main(void *arg) {
 
   int err;
   int radio; /* Radio device file descriptor */
-  uint32_t version = 0;
-  rocket_state_t *state = (rocket_state_t *)(arg);
 
   /* Packet variables. */
 
@@ -150,7 +148,7 @@ static ssize_t transmit(int radio, uint8_t *packet, size_t packet_size) {
   }
   usleep(500000);
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-  printf("Completed transmission of packet #%lu of %ld bytes.\n", ((pkt_hdr_t *)packet)->packet_num,
+  printf("Completed transmission of packet #%u of %ld bytes.\n", ((pkt_hdr_t *)packet)->packet_num,
           packet_size);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   return written;


### PR DESCRIPTION
- Got rid of flight state data. The logging thread now logs in packets, so the file can hopefully be parsed like a radio transmission
- Updated some packet functions and added new ones to allow assembling packets in the style logging/transmission uses
- Got the transmission and logging threads using uORB data and transmitting/logging it
  - Repeated a decent amount of code, which would be great to factor out - couldn't think of a good way to make that happen at the time so leaving it duplicated for now
- Got buffers for fusioned data to be the same size on the transmit/receive ends

Now that we have Josh we can start setting up the correct sensors and data for the board and removing the last hardcoded bits of mocking. I also should probably inspect the files created or use our parsing code to translate them back so we can see if the format being output is actually correct.