### PR TITLE
Use buffers instead of duplicated uORB reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /Kconfig
 Make.dep
 .built
+*/data.img
+*/data_romfs.h
+*.gcda
+*.gcno
+.vscode

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -28,7 +28,8 @@ void *collection_main(void *arg) {
   int err;
   enum flight_state_e flight_state;
   struct timespec start_time;
-  rocket_state_t *state = (rocket_state_t *)(arg);
+  struct collection_args *unpacked_args = (struct collection_args *)(arg);
+  rocket_state_t *state = unpacked_args->state;
 
   struct uorb_inputs sensors;
   clear_uorb_inputs(&sensors);

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -215,7 +215,7 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
   uint8_t *write_to = (*node)->end;
   (*node)->end = next_block;
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-  printf("Allocated %ld bytes for type %d in packet %p, current size %ld\n", next_block - write_to, type, (*node)->packet, (*node)->end - (*node)->packet);
+  //printf("Allocated %ld bytes for type %d in packet %p, current size %ld\n", next_block - write_to, type, (*node)->packet, (*node)->end - (*node)->packet);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   return write_to;
 }

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -38,9 +38,7 @@ static void mag_handler(void *ctx, uint8_t *data);
 static void gnss_handler(void *ctx, uint8_t *data);
 static void gyro_handler(void *ctx, uint8_t *data);
 
-static uint32_t us_to_ms(uint64_t us) {
-  return (uint32_t)(us / 1000);
-}
+#define us_to_ms(us) (us / 1000)
 
 /* How many measurements to read from sensors at a time (match to size of internal buffers) */
 #define BATCH_READ_SIZE 5

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -30,13 +30,16 @@ void *collection_main(void *arg) {
   struct timespec start_time;
   struct collection_args *unpacked_args = (struct collection_args *)(arg);
   rocket_state_t *state = unpacked_args->state;
+  packet_buffer_t *logging_buffer = unpacked_args->logging_buffer;
+  packet_buffer_t *transmit_buffer = unpacked_args->transmit_buffer;
 
   struct uorb_inputs sensors;
   clear_uorb_inputs(&sensors);
-  setup_sensor(&sensors.accel, ORB_ID(fusion_accel));
-  setup_sensor(&sensors.baro, ORB_ID(fusion_baro));
-  struct sensor_accel accel_data[ACCEL_FUSION_BUFFER_SIZE];
-  struct sensor_baro baro_data[BARO_FUSION_BUFFER_SIZE];
+  setup_sensor(&sensors.accel, orb_get_meta("sensor_accel"));
+  setup_sensor(&sensors.baro, orb_get_meta("sensor_baro"));
+  setup_sensor(&sensors.mag, orb_get_meta("sensor_mag"));
+  setup_sensor(&sensors.gyro, org_get_meta("sensor_gyro"));
+  setup_sensor(&sensors.gnss, orb_get_meta("sensor_gnss"));
 
 #if CONFIG_INSPACE_TELEMETRY_RATE != 0
   struct timespec period_start;

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -19,7 +19,11 @@
 #endif /* CONFIG_INSPACE_TELEMETRY_RATE != 0 */
 
 static uint32_t ms_since(struct timespec *start);
+static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum block_type_e type, uint32_t mission_time);
 
+static uint32_t us_to_ms(uint64_t us) {
+  return (uint32_t)(us / 1000);
+}
 
 #define UORB_BUFFER_SIZE 5
 
@@ -36,10 +40,8 @@ void *collection_main(void *arg) {
 
   packet_buffer_t *logging_buffer = unpacked_args->logging_buffer;
   packet_node_t *logging_packet = packet_buffer_get_empty(logging_buffer);
-  uint8_t logging_seq_num = 0;
   packet_buffer_t *transmit_buffer = unpacked_args->transmit_buffer;
   packet_node_t *transmit_packet = packet_buffer_get_empty(transmit_buffer);
-  uint8_t transmit_seq_num = 0;
 
   struct uorb_inputs sensors;
   union uorb_data sensor_data[UORB_BUFFER_SIZE];
@@ -48,7 +50,7 @@ void *collection_main(void *arg) {
   setup_sensor(&sensors.accel, orb_get_meta("sensor_accel"));
   setup_sensor(&sensors.baro, orb_get_meta("sensor_baro"));
   setup_sensor(&sensors.mag, orb_get_meta("sensor_mag"));
-  setup_sensor(&sensors.gyro, org_get_meta("sensor_gyro"));
+  setup_sensor(&sensors.gyro, orb_get_meta("sensor_gyro"));
   setup_sensor(&sensors.gnss, orb_get_meta("sensor_gnss"));
 
 #if CONFIG_INSPACE_TELEMETRY_RATE != 0
@@ -89,22 +91,30 @@ void *collection_main(void *arg) {
     if (data_len > 0) {
       struct sensor_accel *accel_data = (struct sensor_accel *)sensor_data;
       for (int i = 0; i < (data_len / sizeof(struct sensor_accel)); i++) {
-        uint8_t *block = alloc_block(transmit_buffer, &transmit_packet, DATA_ACCEL_ABS, transmit_seq_num, us_to_ms(accel_data[i].timestamp));
-        accel_blk_init((struct accel_blk_t*)block_body(block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
+        uint8_t *block = alloc_block(transmit_buffer, &transmit_packet, DATA_ACCEL_ABS, us_to_ms(accel_data[i].timestamp));
+        if (block) {
+          accel_blk_init((struct accel_blk_t*)block_body(block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
+        }
 
-        block = alloc_block(logging_buffer, &logging_packet, DATA_ACCEL_ABS, logging_seq_num, us_to_ms(accel_data[i].timestamp));
-        accel_blk_init((struct accel_blk_t*)block_body(block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
+        block = alloc_block(logging_buffer, &logging_packet, DATA_ACCEL_ABS, us_to_ms(accel_data[i].timestamp));
+        if (block) {
+          accel_blk_init((struct accel_blk_t*)block_body(block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
+        }
       }
     }
     data_len = get_sensor_data(&sensors.accel, sensor_data, sizeof(struct sensor_baro) * UORB_BUFFER_SIZE);
     if (data_len > 0) {
       struct sensor_baro *baro_data = (struct sensor_baro *)sensor_data;
       for (int i = 0; i < (data_len / sizeof(struct sensor_baro)); i++) {
-        uint8_t *block = alloc_block(transmit_buffer, &transmit_packet, DATA_PRESSURE, transmit_seq_num, us_to_ms(baro_data[i].timestamp));
-        pres_blk_init(block, baro_data[i].pressure);
+        uint8_t *block = alloc_block(transmit_buffer, &transmit_packet, DATA_PRESSURE, us_to_ms(baro_data[i].timestamp));
+        if (block) {
+          pres_blk_init((struct pres_blk_t*)block_body(block), baro_data[i].pressure);
+        }
 
-        block = alloc_block(logging_buffer, &logging_packet, DATA_ACCEL_ABS, logging_seq_num, us_to_ms(baro_data[i].timestamp));
-        pres_blk_init(block, baro_data[i].pressure);
+        block = alloc_block(logging_buffer, &logging_packet, DATA_ACCEL_ABS, us_to_ms(baro_data[i].timestamp));
+        if (block) {
+          pres_blk_init((struct pres_blk_t*)block_body(block), baro_data[i].pressure);
+        }
       }
     }
 
@@ -166,18 +176,21 @@ static uint32_t ms_since(struct timespec *start) {
  * @param buffer The buffer to get a new, empty node from and place full nodes in
  * @param node The current node being worked on
  * @param type The type of block being allocated
- * @param seq_num The sequence number of the packet
  * @param mission_time The time of the measurement, if this block type has one
  * @return The location to write the requested type of block
  */
-static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum block_type_e type, uint32_t *seq_num, uint32_t mission_time) {
+static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum block_type_e type, uint32_t mission_time) {
   // The last byte of the packet will be where the block is allocated, but we need to know where it will end to update (*node)->end
   uint8_t *next_block = pkt_create_blk((*node)->packet, (*node)->end, type, mission_time);
   // Can't add to this packet, it's full or we can just assume its done being asssembled
   if (next_block == NULL) {
-    packet_buffer_put_full(buffer, node);
+    packet_buffer_put_full(buffer, *node);
     (*node) = packet_buffer_get_empty(buffer);
-    (*node)->end = init_pkt((*node)->packet, ++(*seq_num), mission_time);
+    if (*node == NULL) {
+      return NULL;
+    }
+    // Leave seq num up to the logger/transmitter (don't know if or in what order packets get transmitted)
+    (*node)->end = init_pkt((*node)->packet, 0, mission_time);
     next_block = pkt_create_blk((*node)->packet, (*node)->end, type, mission_time);
   }
   uint8_t *write_to = (*node)->end;

--- a/telemetry/src/collection/collection.h
+++ b/telemetry/src/collection/collection.h
@@ -1,6 +1,15 @@
 #ifndef _COLLECTION_H_
 #define _COLLECTION_H_
 
-#endif // _COLLECTION_H_
+#include "../packets/buffering.h"
+
+struct collection_args {
+    rocket_state_t *state;
+    packet_buffer_t *logging_buffer;
+    packet_buffer_t *transmit_buffer;
+};
 
 void *collection_main(void *arg);
+
+#endif // _COLLECTION_H_
+

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -16,11 +16,13 @@ static const char fusion_accel_format[] =
   "fusioned accel - timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";
 static const char fusion_baro_format[] =
   "fusioned baro - timestamp:%" PRIu64 ",pressure:%hf,temperature:%hf";
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-
-/* UORB declarations for fused sensor data */
 ORB_DEFINE(fusion_accel, struct sensor_accel, fusion_accel_format);
 ORB_DEFINE(fusion_baro, struct sensor_baro, fusion_baro_format);
+#else
+/* UORB declarations for fused sensor data */
+ORB_DEFINE(fusion_accel, struct sensor_accel);
+ORB_DEFINE(fusion_baro, struct sensor_baro);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 /* Buffers for inputs, best to match to the size of the internal sensor buffers */
 #define ACCEL_INPUT_BUFFER_SIZE 5

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -10,7 +10,7 @@
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(CONFIG_DEBUG_UORB)
 /* Format strings for fusioned data, useful for printing debug data using orb_info() */
 static const char fusion_accel_format[] =
   "fusioned accel - timestamp:%" PRIu64 ",x:%hf,y:%hf,z:%hf,temperature:%hf";

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -37,7 +37,8 @@ void *logging_main(void *arg) {
 
   int err;
   enum flight_state_e flight_state;
-  rocket_state_t *state = ((rocket_state_t *)(arg));
+  struct logging_args *unpacked_args = (struct logging_args *)(arg);
+  rocket_state_t *state = unpacked_args->state;
 
   char flight_filename[sizeof(CONFIG_INSPACE_TELEMETRY_FLIGHT_FS) +
                        MAX_FILENAME];

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -25,10 +25,6 @@
 #define err_to_ptr(err) ((void *)((err)))
 
 static size_t log_packet(FILE *storage, uint8_t *packet, size_t packet_size);
-static uint8_t *create_block(FILE *storage, uint8_t *packet, uint8_t *block, uint32_t *seq_num, enum block_type_e type, uint32_t mission_time);
-static uint32_t us_to_ms(uint64_t us) {
-  return (uint32_t)(us / 1000);
-}
 
 /*
  * Logging thread which runs to log data to the SD card.

--- a/telemetry/src/logging/logging.h
+++ b/telemetry/src/logging/logging.h
@@ -2,6 +2,12 @@
 #define _INSPACE_LOGGING_H_
 
 #include "../rocket-state/rocket-state.h"
+#include "../packets/buffering.h"
+
+struct logging_args {
+    rocket_state_t *state;
+    packet_buffer_t *buffer;
+};
 
 void *logging_main(void *arg);
 

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -85,6 +85,7 @@ static void packet_queue_lpush(struct packet_queue *queue, packet_node_t *node) 
 static void packet_queue_rpush(struct packet_queue *queue, packet_node_t *node) {
     pthread_mutex_lock(&queue->lock);
     node->prev = queue->tail;
+    node->next = NULL;
     if (queue->tail) {
         queue->tail->next = node;
     } else {
@@ -98,14 +99,21 @@ static void packet_queue_rpush(struct packet_queue *queue, packet_node_t *node) 
  * Initialize a packet buffer. Needs to be called before using the buffer.
  * 
  * @param buffer Pointer to the packet buffer to initialize
+ * @return 0 or a negative error code on failure
  */
-void packet_buffer_init(packet_buffer_t *buffer) {
-    packet_queue_init(&buffer->full_queue);
-    packet_queue_init(&buffer->empty_queue);
-    
+int packet_buffer_init(packet_buffer_t *buffer) {
+    int err = packet_queue_init(&buffer->full_queue);
+    if (err) {
+        return -err;
+    }
+    err = packet_queue_init(&buffer->empty_queue);
+    if (err) {
+        return -err;
+    }
     for (int i = 0; i < PACKET_QUEUE_NUM_BUFFERS; i++) {
         packet_queue_rpush(&buffer->empty_queue, &buffer->buffers[i]);
     }
+    return 0;
 }
 
 /**
@@ -118,11 +126,17 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
     packet_node_t *packet;
     packet = packet_queue_lpop(&buffer->empty_queue);
     if (!packet) {
-        packet_queue_rpop(&buffer->full_queue);
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+        printf("No empty packets to write into, getting a full packet to overwrite\n");
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+        packet = packet_queue_rpop(&buffer->full_queue);
     }
     if (packet) {
         packet->end = packet->packet;
     }
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    printf("Got an packet from the buffer at address %p to write into\n", packet); 
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     // Take from the end, since that should be the oldest packet
     return packet;
 }
@@ -134,6 +148,9 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
  * @return A packet or NULL if there are no full packets in the buffer
  */
 packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    printf("Getting a full packet from the buffer\n");
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     return packet_queue_lpop(&buffer->full_queue);
 }
 
@@ -154,5 +171,14 @@ void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node) {
  * @param node The full packet that is ready to be used by other parts of the system
  */
 void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    printf("Putting a full packet back into the buffer: ");
+    if (node != NULL) {
+        printf("packet of length %d\n", node->end - node->packet);
+    }
+    else {
+        printf("node is NULL\n");
+    }
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
     packet_queue_lpush(&buffer->full_queue, node);
 }

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -2,6 +2,7 @@
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
 #include <stdio.h>
+//#define PACKET_BUFFERING_DEBUG
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 
@@ -59,9 +60,9 @@ static packet_node_t* packet_queue_wait_lpop(struct packet_queue *queue) {
     pthread_mutex_lock(&queue->lock);
 
     while (queue->head == NULL) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(PACKET_BUFFERING_DEBUG)
         printf("Waiting for a full packet\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+#endif /* defined(PACKET_BUFFERING_DEBUG) */
         pthread_cond_wait(&queue->not_empty, &queue->lock);
     }
 
@@ -150,17 +151,17 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
     packet_node_t *packet;
     packet = packet_queue_lpop(&buffer->empty_queue);
     if (!packet) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(PACKET_BUFFERING_DEBUG)
         printf("No empty packets to write into, getting a full packet to overwrite\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+#endif /* defined(PACKET_BUFFERING_DEBUG) */
         packet = packet_queue_rpop(&buffer->full_queue);
     }
     if (packet) {
         packet->end = packet->packet;
     }
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(PACKET_BUFFERING_DEBUG)
     printf("Got an packet from the buffer at address %p to write into\n", packet); 
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+#endif /* defined(PACKET_BUFFERING_DEBUG) */
     // Take from the end, since that should be the oldest packet
     return packet;
 }
@@ -172,9 +173,9 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
  * @return A packet that has 0 or more bytes in it
  */
 packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(PACKET_BUFFERING_DEBUG)
     printf("Getting a full packet from the buffer\n");
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+#endif /* defined(PACKET_BUFFERING_DEBUG) */
     return packet_queue_wait_lpop(&buffer->full_queue);
 }
 
@@ -195,7 +196,7 @@ void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node) {
  * @param node The full packet that is ready to be used by other parts of the system
  */
 void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#if defined(PACKET_BUFFERING_DEBUG)
     printf("Putting a full packet back into the buffer: ");
     if (node != NULL) {
         printf("packet of length %d\n", node->end - node->packet);
@@ -203,6 +204,6 @@ void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node) {
     else {
         printf("node is NULL\n");
     }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+#endif /* defined(PACKET_BUFFERING_DEBUG) */
     packet_queue_push(&buffer->full_queue, node);
 }

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -117,11 +117,14 @@ void packet_buffer_init(packet_buffer_t *buffer) {
 packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
     packet_node_t *packet;
     packet = packet_queue_lpop(&buffer->empty_queue);
+    if (!packet) {
+        packet_queue_rpop(&buffer->full_queue);
+    }
     if (packet) {
-        return packet;
+        packet->end = packet->packet;
     }
     // Take from the end, since that should be the oldest packet
-    return packet_queue_rpop(&buffer->full_queue);
+    return packet;
 }
 
 /**

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -1,0 +1,155 @@
+#include "buffering.h"
+
+/**
+ * Initialize a packet queue. Must be performed before using the queue
+ * 
+ * @param queue Pointer to the queue
+ * @return 0 on success, non-zero error code on mutex initialization failure
+ */
+static int packet_queue_init(struct packet_queue *queue) {
+    int err = pthread_mutex_init(&queue->lock, NULL);
+    queue->head = NULL;
+    queue->tail = NULL;
+    return err;
+}
+
+/**
+ * Remove and return the first node from the queue
+ * 
+ * @param queue Pointer to the queue
+ * @return Pointer to the removed node, or NULL if queue is empty
+ */
+static packet_node_t* packet_queue_lpop(struct packet_queue *queue) {
+    packet_node_t *node = NULL;
+    pthread_mutex_lock(&queue->lock);
+    if (queue->head) {
+        node = queue->head;
+        queue->head = node->next;
+        if (queue->head) {
+            queue->head->prev = NULL;
+        } else {
+            queue->tail = NULL;
+        }
+    }
+    pthread_mutex_unlock(&queue->lock);
+    return node;
+}
+
+/**
+ * Remove and return the last node from the queue
+ * 
+ * @param queue Pointer to the queue
+ * @return Pointer to the removed node, or NULL if queue is empty
+ */
+static packet_node_t* packet_queue_rpop(struct packet_queue *queue) {
+    packet_node_t *node = NULL;
+    pthread_mutex_lock(&queue->lock);
+    if (queue->tail) {
+        node = queue->tail;
+        queue->tail = node->prev;
+        if (queue->tail) {
+            queue->tail->next = NULL;
+        } else {
+            queue->head = NULL;
+        }
+    }
+    pthread_mutex_unlock(&queue->lock);
+    return node;
+}
+
+/**
+ * Add a node to the front of the queue.
+ * 
+ * @param queue Pointer to the queue structure
+ * @param node Pointer to the node to add
+ */
+static void packet_queue_lpush(struct packet_queue *queue, packet_node_t *node) {
+    pthread_mutex_lock(&queue->lock);
+    node->next = queue->head;
+    node->prev = NULL;
+    if (queue->head) {
+        queue->head->prev = node;
+    } else {
+        queue->tail = node;
+    }
+    queue->head = node;
+    pthread_mutex_unlock(&queue->lock);
+}
+
+/**
+ * Add a node to the end of the queue.
+ * 
+ * @param queue Pointer to the queue structure
+ * @param node Pointer to the node to add
+ */
+static void packet_queue_rpush(struct packet_queue *queue, packet_node_t *node) {
+    pthread_mutex_lock(&queue->lock);
+    node->prev = queue->tail;
+    if (queue->tail) {
+        queue->tail->next = node;
+    } else {
+        queue->head = node;
+    }
+    queue->tail = node;
+    pthread_mutex_unlock(&queue->lock);
+}
+
+/**
+ * Initialize a packet buffer. Needs to be called before using the buffer.
+ * 
+ * @param buffer Pointer to the packet buffer to initialize
+ */
+void packet_buffer_init(packet_buffer_t *buffer) {
+    packet_queue_init(&buffer->full_queue);
+    packet_queue_init(&buffer->empty_queue);
+    
+    for (int i = 0; i < PACKET_QUEUE_NUM_BUFFERS; i++) {
+        packet_queue_rpush(&buffer->empty_queue, &buffer->buffers[i]);
+    }
+}
+
+/**
+ * Takes an empty packet or the oldest full packet from the buffer
+ * 
+ * @param buffer The buffer to get the packet from
+ * @return A packet or NULL if there are no packets in the buffer
+ */
+packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
+    packet_node_t *packet;
+    packet = packet_queue_lpop(&buffer->empty_queue);
+    if (packet) {
+        return packet;
+    }
+    // Take from the end, since that should be the oldest packet
+    return packet_queue_rpop(&buffer->full_queue);
+}
+
+/**
+ * Takes a full packet from the buffer
+ * 
+ * @param buffer The buffer to get the packet from
+ * @return A packet or NULL if there are no full packets in the buffer
+ */
+packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer) {
+    return packet_queue_lpop(&buffer->full_queue);
+}
+
+/**
+ * Puts a empty or used packet back into the buffer
+ * 
+ * @param buffer The buffer to put the packet into
+ * @param node The empty or used packet which can now be overwritten
+ */
+void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node) {
+    packet_queue_lpush(&buffer->empty_queue, node);
+}
+
+/**
+ * Puts a full packet back into the buffer
+ * 
+ * @param buffer The buffer to put the packet into
+ * @param node The full packet that is ready to be used by other parts of the system
+ */
+void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node) {
+    packet_queue_lpush(&buffer->full_queue, node);
+}

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -11,6 +11,8 @@ typedef struct packet_node packet_node_t;
 struct packet_node {
     /* A packet that can be written directly to the radio or storage medium */
     uint8_t packet[PACKET_MAX_SIZE];
+    /* Points to the end of a packet, where the blocks stop */
+    uint8_t *end;
     /* The next node in the packet queue */
     packet_node_t *next;
     /* The previous node in the packet queue */

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -1,0 +1,35 @@
+#ifndef _INSPACE_PACKET_QUEUE_H_
+#define _INSPACE_PACKET_QUEUE_H_
+
+#include <pthread.h>
+#include <stdbool.h>
+#include "packets.h"
+
+typedef struct packet_node packet_node_t;
+
+struct packet_node {
+    uint8_t packet[PACKET_MAX_SIZE];
+    packet_node_t *next;
+    packet_node_t *prev;
+};
+
+struct packet_queue {
+    pthread_mutex_t lock;
+    packet_node_t *head;
+    packet_node_t *tail;
+};
+
+#define PACKET_QUEUE_NUM_BUFFERS 3
+
+typedef struct {
+    packet_node_t buffers[PACKET_QUEUE_NUM_BUFFERS];
+    struct packet_queue full_queue;
+    struct packet_queue empty_queue;
+} packet_buffer_t;
+
+void packet_buffer_init(packet_buffer_t *buffer); 
+packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer);
+packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer);
+void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node);
+void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node);
+#endif // _INSPACE_PACKET_QUEUE_H_

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -42,7 +42,7 @@ typedef struct {
     struct packet_queue empty_queue;
 } packet_buffer_t;
 
-void packet_buffer_init(packet_buffer_t *buffer); 
+int packet_buffer_init(packet_buffer_t *buffer);
 packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer);
 packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer);
 void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node);

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -2,7 +2,6 @@
 #define _INSPACE_PACKET_QUEUE_H_
 
 #include <pthread.h>
-#include <stdbool.h>
 #include "packets.h"
 
 typedef struct packet_node packet_node_t;
@@ -23,6 +22,8 @@ struct packet_node {
 struct packet_queue {
     /* A lock for concurrency */
     pthread_mutex_t lock;
+    /* Allows consumers to wait on new packets */
+    pthread_cond_t not_empty;
     /* The first node in the queue */
     packet_node_t *head;
     /* The last node in the queue */

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -7,23 +7,36 @@
 
 typedef struct packet_node packet_node_t;
 
+/* The data type exchanged by the buffer */
 struct packet_node {
+    /* A packet that can be written directly to the radio or storage medium */
     uint8_t packet[PACKET_MAX_SIZE];
+    /* The next node in the packet queue */
     packet_node_t *next;
+    /* The previous node in the packet queue */
     packet_node_t *prev;
 };
 
+/* A doubly-linked list used to store packets that can be used concurrently */
 struct packet_queue {
+    /* A lock for concurrency */
     pthread_mutex_t lock;
+    /* The first node in the queue */
     packet_node_t *head;
+    /* The last node in the queue */
     packet_node_t *tail;
 };
 
+/* The number of buffers statically allocated to the packet buffer, to save allocation time */
 #define PACKET_QUEUE_NUM_BUFFERS 3
 
+/* Uses doubly-linked lists to offer a queue of packets for a writer and single reader */
 typedef struct {
+    /* Statically allocated buffers, added upon initialization */
     packet_node_t buffers[PACKET_QUEUE_NUM_BUFFERS];
+    /* A queue of full packets, to be logged or transmitted */
     struct packet_queue full_queue;
+    /* A queue of empty packets to be written into */
     struct packet_queue empty_queue;
 } packet_buffer_t;
 
@@ -32,4 +45,5 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer);
 packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer);
 void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node);
 void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node);
+
 #endif // _INSPACE_PACKET_QUEUE_H_

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -100,7 +100,7 @@ void poll_sensors(struct uorb_inputs *sensors) {
  * @param elem_size The size of this type's elements
  * @return The number of bytes read from the sensors
  */
-void for_all_data(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size) {
+void read_until_empty(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size) {
   if (sensor->revents == POLLIN) {
     ssize_t len = 0;
     do {

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -49,21 +49,38 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
  * @param size The size of the data parameter in bytes
  * @return The number of bytes read from the sensor or 0 if there was none to read
  */
-ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
-    /*
-     * If the sensor wasn't set up right, POLLIN won't get set, meaning there's no need to avoid using
-     * the sensor if its metadata or fd weren't set up properly
-     */
-    if (sensor->revents == POLLIN) {
-      ssize_t len = orb_copy_multi(sensor->fd, data, size);
-      if (len < 0) {
+ssize_t get_sensor_data(struct pollfd *sensor, uint8_t *data, size_t size) {
+ /*
+  * If the sensor wasn't set up right, POLLIN won't get set, meaning there's no need to avoid using
+  * the sensor if its metadata or fd weren't set up properly
+  */
+  if (sensor->revents == POLLIN) {
+    ssize_t len = orb_copy_multi(sensor->fd, data, size);
+    if (len < 0) {
+      int err = errno;
+      // If there's no data to read or there's no fetch function, but that shouldn't happen if we get POLLIN
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-        fprintf(stderr, "Collection: Error reading from uORB data: %ld\n", len);
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      if (errno != ENODATA) {
+        fprintf(stderr, "Error reading from uORB data: %d\n", err);
       }
-      return len;
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+      return 0;
     }
-    return 0;
+    return len;
+  }
+  return 0;
+}
+
+/**
+ * Does the same thing as get_sensor_data, but returns the last byte of the read data
+ *
+ * @param sensor A pollfd struct with a valid or invalid file descriptor
+ * @param data An array of uORB data structs of the type this sensor uses
+ * @param size The size of the data parameter in bytes
+ * @return The 
+ */
+uint8_t *get_sensor_data_end(struct pollfd *sensor, uint8_t* data, size_t size) {
+  return data + get_sensor_data(sensor, data, size);
 }
 
 /**
@@ -91,72 +108,34 @@ void poll_sensors(struct uorb_inputs *sensors) {
 
 /**
  * Perform an operation on each piece of uORB data in a buffer
- * 
+ *
  * @param handler The operation to perform on each piece of data
- * @param handler_context Information passed to the handler as its first argument 
+ * @param handler_context Information passed to the handler as its first argument
  * @param buf The buffer to read data from
- * @param size The number of bytes of data in the buffer
+ * @param len The number of bytes of data in the buffer
  * @param elem_size The size of each element in the data buffer
  */
-static void foreach_measurement(uorb_data_callback_t handler, void* handler_context, uint8_t *buf, size_t size, size_t elem_size) {
-  for (int i = 0; i < (size / elem_size); i++) {
+void foreach_measurement(uorb_data_callback_t handler, void* handler_context, uint8_t *buf, size_t len, size_t elem_size) {
+  for (int i = 0; i < (len / elem_size); i++) {
     handler(handler_context, buf + (i * elem_size));
   }
 }
 
 /**
- * Read data from uORB if there's new data to be read
- * 
- * @param sensor The sensor to read data from (must have a POLLIN event set)
- * @param buf The buffer to read data into, should be an array of structs of this sensor's data type
- * @param size The size of the buffer in bytes
- * @return The number of bytes read from the sensor. 0 if there was no data to read or an error occured
- */
-static ssize_t uorb_read(struct pollfd* sensor, uint8_t *buf, size_t size) {
-  if (sensor->revents == POLLIN) {
-    ssize_t len = orb_copy_multi(sensor->fd, buf, size);
-    if (len < 0) {
-      int err = errno;
-      // If there's no data to read or there's no fetch function, but that shouldn't happen if we get POLLIN
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-      if (errno != ENODATA) {
-        fprintf(stderr, "Collection: Error reading from uORB data: %ld\n", err);
-      }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-      return 0;
-    }
-    return len;
-  }
-  return 0;
-}
-
-/**
- * Calls a handler function for each piece of data a sensor has availible, if it has new data
+ * Process one piece of data
  *
- * @param handler The function to call on each piece of new data from the sensor
- * @param handler_context Information to be passed to the handler as its first argument
- * @param sensor The sensor to check for data
- * @param buf The buffer to read data into, should be at least as large as the structure this sensor uses
- * @param size The size of the buffer in bytes
- * @param elem_size The size of this type's elements
- * @return The number of bytes read from the sensors
+ * @param handler The handler to call on a single element in the data buffer
+ * @param handler_context 
+ * @param data_start A pointer to the next place in the data buffer to process, incremented by elem_size if the handler is called
+ * @param data_end The last byte in the data buffer where there is data
+ * @param elem_size The size of elements in the buffer
+ * @return 1 if a piece of data was processed, 0 otherwise
  */
-void read_until_empty(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size) {
-  while (read_once(handler, handler_context, sensor, buf, size, elem_size) > 0) {}
-}
-
-/**
- * Calls a handler function on data from a single read from a sensor
- * @param handler The function to call on each piece of new data from the sensor
- * @param handler_context Information to be passed to the handler as its first argument
- * @param sensor The sensor to check for data
- * @param buf The buffer to read data into, should be at least as large as the structure this sensor uses
- * @param size The size of the buffer in bytes
- * @param elem_size The size of this type's elements
- * @return The number of bytes read from the sensors
- */
-ssize_t read_once(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size) {
-  ssize_t len = uorb_read(sensor, buf, size);
-  foreach_measurement(handler, handler_context, buf, size, elem_size);
-  return len;
+int process_one(uorb_data_callback_t handler, void* handler_context, uint8_t **data_start, uint8_t *data_end, size_t elem_size) {
+  if ((*data_start == data_end) || ((elem_size + *data_start) > data_end)) {
+    return 0;
+  }
+  handler(handler_context, (*data_start));
+  (*data_start) += elem_size;
+  return 1;
 }

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -34,11 +34,11 @@ union uorb_data {
 typedef void (*uorb_data_callback_t)(void* context, uint8_t* element);
 
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
-ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
+ssize_t get_sensor_data(struct pollfd *sensor, uint8_t *data, size_t size);
+uint8_t *get_sensor_data_end(struct pollfd *sensor, uint8_t* data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
-void read_until_empty(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
-ssize_t read_once(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
+void foreach_measurement(uorb_data_callback_t handler, void* handler_context, uint8_t *buf, size_t size, size_t elem_size);
+int process_one(uorb_data_callback_t handler, void* handler_context, uint8_t **data_start, uint8_t *data_end, size_t elem_size);
 
 #endif // _INSPACE_SENSORS_H_
-

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -38,6 +38,7 @@ ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
 void read_until_empty(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
+ssize_t read_once(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
 
 #endif // _INSPACE_SENSORS_H_
 

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -5,7 +5,6 @@
 #include <poll.h>
 
 /* Used for polling on multiple sensors at once. Don't set up the ones you don't want to use */
-
 struct uorb_inputs {
   struct pollfd accel;
   struct pollfd baro;
@@ -15,7 +14,6 @@ struct uorb_inputs {
 };
 
 /* A buffer that can hold any of the types of data created by the sensors in uorb_inputs */
-
 union uorb_data {
   struct sensor_accel accel;
   struct sensor_baro baro;

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -37,7 +37,7 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta);
 ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
-void for_all_data(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
+void read_until_empty(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
 
 #endif // _INSPACE_SENSORS_H_
 

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -26,20 +26,18 @@ union uorb_data {
 #define NUM_SENSORS sizeof(struct uorb_inputs) / sizeof(struct pollfd)
 
 /**
- * A function pointer to a function that will perform operations on single reads of uORB data
+ * A function pointer to a function that will perform operations on single pieces of uORB data
  *
- * @param context Context given to the callback from the user
- * @param sensor_type The type of the sensor the data is from
- * @param buf A buffer at least the size of the struct that the type of sensor uses
- * @param bufsize The size of the buffer in bytes
+ * @param context Context given to the callback by the program using this interface
+ * @param element The element to perform processing on, where the length is implied by knowing the type of element
  */
-typedef void (*uorb_data_callback_t)(void* context, uint8_t* buf, size_t bufsize);
+typedef void (*uorb_data_callback_t)(void* context, uint8_t* element);
 
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
 ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
-void for_all_data(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size);
+void for_all_data(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size, size_t elem_size);
 
 #endif // _INSPACE_SENSORS_H_
 

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -5,18 +5,43 @@
 #include <poll.h>
 
 /* Used for polling on multiple sensors at once. Don't set up the ones you don't want to use */
+
 struct uorb_inputs {
   struct pollfd accel;
   struct pollfd baro;
+  struct pollfd mag;
+  struct pollfd gyro;
+  struct pollfd gnss;
+};
+
+/* A buffer that can hold any of the types of data created by the sensors in uorb_inputs */
+
+union uorb_data {
+  struct sensor_accel accel;
+  struct sensor_baro baro;
+  struct sensor_mag mag;
+  struct sensor_gyro gyro;
+  struct sensor_gnss gnss;
 };
 
 /* The numbers of sensors defined in uorb_inputs */
 #define NUM_SENSORS sizeof(struct uorb_inputs) / sizeof(struct pollfd)
 
+/**
+ * A function pointer to a function that will perform operations on single reads of uORB data
+ *
+ * @param context Context given to the callback from the user
+ * @param sensor_type The type of the sensor the data is from
+ * @param buf A buffer at least the size of the struct that the type of sensor uses
+ * @param bufsize The size of the buffer in bytes
+ */
+typedef void (*uorb_data_callback_t)(void* context, uint8_t* buf, size_t bufsize);
+
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
 ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
+void for_all_data(uorb_data_callback_t handler, void* handler_context, struct pollfd *sensor, uint8_t *buf, size_t size);
 
 #endif // _INSPACE_SENSORS_H_
 

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -11,11 +11,17 @@
 #include "logging/logging.h"
 #include "transmission/transmit.h"
 #include "fusion/fusion.h"
+#include "packets/buffering.h"
 
 int main(int argc, char **argv) {
 
   int err = 0;
   rocket_state_t state; /* The shared rocket state. */
+
+  /* Buffers for sharing sensor data between threads */
+
+  packet_buffer_t transmit_buffer;
+  packet_buffer_t logging_buffer;
 
   /* Thread handles. */
 
@@ -40,8 +46,9 @@ int main(int argc, char **argv) {
 
   /* Start all threads */
 
+  struct collection_args collect_thread_args = {.state = &state, .transmit_buffer = &transmit_buffer, .logging_buffer = &logging_buffer};
+  err = pthread_create(&collect_thread, NULL, collection_main, &collect_thread_args);
   // TODO: handle thread creation errors better
-  err = pthread_create(&collect_thread, NULL, collection_main, &state);
   if (err) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Problem starting collection thread: %d\n", err);
@@ -49,7 +56,8 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  err = pthread_create(&transmit_thread, NULL, transmit_main, &state);
+  struct transmit_args transmit_thread_args = {.state = &state, .buffer = &transmit_buffer};
+  err = pthread_create(&transmit_thread, NULL, transmit_main, &transmit_thread_args);
   if (err) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Problem starting transmission thread: %d\n", err);
@@ -57,7 +65,8 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  err = pthread_create(&log_thread, NULL, logging_main, &state);
+  struct logging_args logging_thread_args = {.state = &state, .buffer = &logging_buffer};
+  err = pthread_create(&log_thread, NULL, logging_main, &logging_thread_args);
   if (err) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Problem starting logging thread: %d\n", err);

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -44,6 +44,21 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
+  err = packet_buffer_init(&transmit_buffer);
+  if (err) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Could not initialize transmit buffer: %d\n", err);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    exit(EXIT_FAILURE);
+  }
+  
+  err = packet_buffer_init(&logging_buffer);
+  if (err) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Could not initialize logging buffer: %d\n", err);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    exit(EXIT_FAILURE);
+  }
   /* Start all threads */
 
   struct collection_args collect_thread_args = {.state = &state, .transmit_buffer = &transmit_buffer, .logging_buffer = &logging_buffer};

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -29,6 +29,8 @@ void *transmit_main(void *arg) {
   int err;
   int radio; /* Radio device file descriptor */
 
+  struct transmit_args *unpacked_args = (struct transmit_args *)arg;
+
   /* Packet variables. */
 
   uint8_t packet[PACKET_MAX_SIZE];     /* Array of bytes for packet */

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -18,25 +18,16 @@
 #define err_to_ptr(err) ((void *)((err)))
 
 static ssize_t transmit(int radio, uint8_t *packet, size_t packet_size);
-static uint8_t *create_block(int radio, uint8_t *packet, uint8_t *block, uint32_t *seq_num, enum block_type_e type, uint32_t mission_time);
-static uint32_t us_to_ms(uint64_t us) {
-  return (uint32_t)(us / 1000);
-}
 
 /* Main thread for data transmission over radio. */
 void *transmit_main(void *arg) {
 
   int err;
   int radio; /* Radio device file descriptor */
-
   struct transmit_args *unpacked_args = (struct transmit_args *)arg;
-
-  /* Packet variables. */
-
-  uint8_t packet[PACKET_MAX_SIZE];     /* Array of bytes for packet */
-  uint8_t *current_block = packet;     /* Location in packet buffer */
-  uint8_t *next_block;                 /* Next block in packet buffer */
-  uint32_t seq_num = 0;                /* Packet numbering */
+  rocket_state_t *state = unpacked_args->state;
+  packet_buffer_t *buffer = unpacked_args->buffer;
+  uint32_t seq_num = 0;
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
   printf("Transmit thread started.\n");
@@ -53,40 +44,13 @@ void *transmit_main(void *arg) {
     pthread_exit(err_to_ptr(err)); // TODO: handle more gracefully
   }
 
-  struct uorb_inputs sensors;
-  clear_uorb_inputs(&sensors);
-  setup_sensor(&sensors.accel, ORB_ID(fusion_accel));
-  setup_sensor(&sensors.baro, ORB_ID(fusion_baro));
-  struct sensor_accel accel_data[ACCEL_FUSION_BUFFER_SIZE];
-  struct sensor_baro baro_data[BARO_FUSION_BUFFER_SIZE];
-
   /* Transmit forever, regardless of rocket flight state. */
 
   for (;;) {
-    /* Wait for new data */
-    poll_sensors(&sensors);
-    // Get data together, so we can block on transmit and not lose the data we're currently using
-    // Could also ask for the minimum of the free space in the size of the buffer to save effort
-    ssize_t accel_len = get_sensor_data(&sensors.accel, accel_data, sizeof(accel_data));
-    ssize_t baro_len = get_sensor_data(&sensors.baro, baro_data, sizeof(baro_data));
-    if (accel_len > 0) {
-      for (int i = 0; i < (accel_len / sizeof(struct sensor_accel)); i++) {
-        next_block = create_block(radio, packet, current_block, &seq_num, DATA_ACCEL_ABS, us_to_ms(accel_data[i].timestamp));
-        accel_blk_init((struct accel_blk_t*)block_body(current_block), accel_data[i].x, accel_data[i].y, accel_data[i].z);
-        current_block = next_block;
-      }
-    }
-    if (baro_len > 0) {
-      for (int i = 0; i < (baro_len / sizeof(struct sensor_baro)); i++) {
-        next_block = create_block(radio, packet, current_block, &seq_num, DATA_PRESSURE, us_to_ms(baro_data[i].timestamp));
-        pres_blk_init((struct pres_blk_t*)block_body(current_block), baro_data[i].pressure);
-        current_block = next_block;
-
-        next_block = create_block(radio, packet, current_block, &seq_num, DATA_TEMP, us_to_ms(baro_data[i].timestamp));
-        temp_blk_init((struct temp_blk_t*)block_body(current_block), baro_data[i].temperature);
-        current_block = next_block;
-      }
-    }
+      packet_node_t *next_packet = packet_buffer_get_full(buffer);
+      ((pkt_hdr_t *)next_packet->packet)->packet_num = seq_num++;
+      transmit(radio, next_packet->packet, next_packet->end - next_packet->packet);
+      packet_buffer_put_empty(buffer, next_packet);
   }
 
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
@@ -97,36 +61,6 @@ void *transmit_main(void *arg) {
   close(radio);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
   pthread_exit(err_to_ptr(err));
-}
-
-/**
- * Create a block and set it up, or transmit and make a new packet if a block can't be added
- *
- * @param radio The radio to write the packet to when full
- * @param packet The packet to write to
- * @param block The block to create and initialize the header and time for
- * @param seq_num The current sequence number, incremented if a packet is transmitted
- * @param type The type of block to add
- * @param mission_time If the type of block requires a time, the time to use
- * @return The start of the next block
- */
-static uint8_t *create_block(int radio, uint8_t *packet, uint8_t *block, uint32_t *seq_num, enum block_type_e type, uint32_t mission_time) {
-  uint8_t *next_block = pkt_create_blk(packet, block, type, mission_time);
-  if (next_block == NULL) {
-    if (block != packet) {
-      transmit(radio, packet, block - packet);
-      *seq_num += 1;
-    }
-    // We can delay setting up the header and just let the addition of the first block fail
-    block = init_pkt(packet, *seq_num, mission_time);
-    next_block = pkt_create_blk(packet, block, type, mission_time);
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    if (next_block == NULL) {
-      fprintf(stderr, "Error adding block to packet after transmission, should not be possible\n");
-    }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-  }
-  return next_block;
 }
 
 /**

--- a/telemetry/src/transmission/transmit.h
+++ b/telemetry/src/transmission/transmit.h
@@ -2,6 +2,12 @@
 #define _INSPACE_TRANSMIT_H_
 
 #include "../rocket-state/rocket-state.h"
+#include "../packets/buffering.h"
+
+struct transmit_args {
+    rocket_state_t *state;
+    packet_buffer_t *buffer;
+};
 
 void *transmit_main(void *arg);
 


### PR DESCRIPTION
## Summary

Using buffers instead of duplicating the uORB reading has a number of advantages
- Data is read and encoded while logging/transmit are blocked, so that when they wake up they can go right back to writing
- Data is only read from uORB once, instead of twice. It is still encoded twice right now, but that could be worked on
- Multiple packets can be queued up for transmission/logging at once
- The amount of buffering can be configured or even changed dynamically
- Buffers and encoded packets could eventually be shared between logging/transmit to cut down on the number of copies
- Transmit/logging threads have fewer concerns

There were a number of changes required for this redesign
- New types for packet buffers, which are currently implemented as two doubly-linked lists that hold full packets and empty packets to overwrite. These achieve the following goals: the most recent packets are recorded first, if there are no empty packets the oldest full one will be used instead, static allocation, and less locks/atomics. Currently two of these packet buffers are created, one for transmit and one for logging. This allows the contents of the packets to be tailored for each of the threads.
- A new function was added to sensors.c that cuts down on repeated code for reading in uORB data. It comes at the cost of using function pointers but these are relatively simple ones and cut down on a lot of clutter.
- Arguments passed to threads were formalized into structs, allowing buffers to be passed in.
- The rest of the sensor types were added and set up for collection.c - these just need to be connected to the code for initializing their blocks.

## Testing

Tested on sim:nsh, run for a number of seconds just to confirm everything looks okay. Next step is to run on Josh of course. I'll probably set up the rest of sensor types first.

```
nsh> inspace_telem
You are running the Carleton University InSpace telemetry system.
Setup successful for sensor sensor_accel
Setup successful for sensor sensor_baro
Setup successful for sensor sensor_mag
Setup successful for sensor sensor_gyro
Setup successful for sensor sensor_gnss
Collection thread started.
Transmit thread started.
Logging thread started.
Setup successful for sensor sensor_accel
Setup successful for sensor sensor_baro
Completed a packet length 0
Completed a packet length 0
Logged 0 bytes
Completed transmission of packet #0 of 0 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #1 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #2 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #3 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #4 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #5 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
Completed transmission of packet #6 of 246 bytes.
Completed a packet length 246
Completed a packet length 246
Logged 246 bytes
```


