### PR TITLE
Add necessary configuration for a hardware radio

### DIFF
--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -7,7 +7,7 @@
 
 /* The maximum size a packet can be in bytes. */
 
-#define PACKET_MAX_SIZE 256
+#define PACKET_MAX_SIZE 255
 
 /* The maximum size a block can be in bytes. */
 


### PR DESCRIPTION
- Added configuration options for the radio (but kept the sync word commented out for now)
  - Didn't add these configuration options to the kconfig because of how many options we'd need and how infrequently we'll likely change these. I could add them but it might just be easier to modify the values in code
- Removed timed sleeps from collection since these aren't necessary if we set intervals of sensors instead. This will reduce wasteful sensor reads. Currently we log and transmit faster than we can collect data so adding these intervals and deciding their values isn't a priority
- Didn't add any requirement to enable to RN2483 and included its code in a conditional block dependent on the RN2483 being enabled. This means we can still do mocking and write to a regular file.