### PR TITLE
Add remaining sensor types to collection

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -39,9 +39,40 @@ static void mag_handler(void *ctx, uint8_t *data);
 static void gnss_handler(void *ctx, uint8_t *data);
 static void gyro_handler(void *ctx, uint8_t *data);
 
+/* Convert microseconds to milliseconds */
+
 #define us_to_ms(us) (us / 1000)
 
+/* Convert millibar to pascals */
+
+#define pascals(millibar) (millibar * 100)
+
+/* Convert meters to millimeters */
+
+#define millimeters(meters) (meters * 1000)
+
+/* Convert a degree to a tenth of a microdegree */
+
+#define point_one_microdegrees(degrees) (1E7f * degrees)
+
+/* Convert a radian to a tenth of a degree */
+
+#define tenth_degree(radian) (radian * 18 / M_PI)
+
+/* Convert gauss to milligauss */
+
+#define milligauss(gauss) (gauss * 1000)
+
+/* Convert meters per second squared to centimeters per second squared */
+
+#define cm_per_sec_squared(meters_per_sec_squared) (meters_per_sec_squared * 100)
+
+/* Convert a degrees celsius to millidegrees */
+
+#define millidegrees(celsius) (celsius * 1000)
+
 /* How many measurements to read from sensors at a time (match to size of internal buffers) */
+
 #define ACCEL_READ_SIZE 5
 #define BARO_READ_SIZE 5
 #define MAG_READ_SIZE 5
@@ -242,13 +273,6 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
 }
 
 /**
- * Convert millibar to pascals
- */
-static float pascals(float millibar) {
-  return millibar * 100;
-}
-
-/**
  * Add a pressure block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -260,13 +284,6 @@ static void add_pres_blk(packet_buffer_t *buffer, packet_node_t **node, struct s
   if (block) {
     pres_blk_init((struct pres_blk_t*)block_body(block), pascals(baro_data->pressure));
   }
-}
-
-/**
- * Convert a degrees celsius to millidegrees
- */
-static float millidegrees(float celsius) {
-  return celsius * 1000;
 }
 
 /**
@@ -300,13 +317,6 @@ static void baro_handler(void *ctx, uint8_t *data) {
 }
 
 /**
- * Convert meters per second squared to centimeters per second squared
- */
-static float cm_per_sec_squared(float meters_per_sec_squared) {
-  return meters_per_sec_squared * 100;
-}
-
-/**
  * Add an acceleration block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -334,13 +344,6 @@ static void accel_handler(void *ctx, uint8_t *data) {
 }
 
 /**
- * Convert gauss to milligauss
- */
-static float milligauss(float gauss) {
-  return gauss * 1000;
-}
-
-/**
  * Add a magnetometer block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -365,14 +368,6 @@ static void mag_handler(void *ctx, uint8_t *data) {
   processing_context_t *context = (processing_context_t *)ctx;
   add_mag_blk(context->logging_buffer, &context->logging_packet, mag_data);
   add_mag_blk(context->transmit_buffer, &context->transmit_packet, mag_data);
-}
-
-
-/**
- * Convert a radian to a tenth of a degree
- */
-static float tenth_degree(float radian) {
-  return radian * 18 / M_PI;
 }
 
 /**
@@ -403,13 +398,6 @@ static void gyro_handler(void *ctx, uint8_t *data) {
 }
 
 /**
- * Convert a degree to a tenth of a microdegree
- */
-static float point_one_microdegrees(float degrees) {
-  return 1E7f * degrees;
-}
-
-/**
  * Add an gnss block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -421,13 +409,6 @@ static void add_gnss_block(packet_buffer_t *buffer, packet_node_t **node, struct
   if (block) {
     coord_blk_init((struct coord_blk_t*)block_body(block), point_one_microdegrees(gnss_data->latitude), point_one_microdegrees(gnss_data->longitude));
   }
-}
-
-/**
- * Convert meters to millimeters
- */
-static float millimeters(float meters) {
-  return meters * 1000;
 }
 
 /**

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -334,13 +334,37 @@ static void accel_handler(void *ctx, uint8_t *data) {
 }
 
 /**
+ * Convert gauss to milligauss
+ */
+static float milligauss(float gauss) {
+  return gauss * 1000;
+}
+
+/**
+ * Add a magnetometer block to the packet being assembled
+ * 
+ * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param node The packet currently being assembled
+ * @param mag_data The magnetic field data to add
+ */
+static void add_mag_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_mag *mag_data) {
+  uint8_t *block = alloc_block(buffer, node, DATA_MAGNETIC, us_to_ms(mag_data->timestamp));
+  if (block) {
+    mag_blk_init((struct mag_blk_t*)block_body(block), milligauss(mag_data->x), milligauss(mag_data->y), milligauss(mag_data->z));
+  }
+}
+
+/**
  * A uorb_data_callback_t function - adds magnetometer data to the required packets
  *  
  * @param ctx Context information, type processing_context_t
  * @param data magnetometer data to add, type struct sensor_mag
  */
 static void mag_handler(void *ctx, uint8_t *data) {
-  // TODO - currently no definition for magnetometer data in packet spec
+  struct sensor_mag *mag_data = (struct sensor_mag*)data;
+  processing_context_t *context = (processing_context_t *)ctx;
+  add_mag_blk(context->logging_buffer, &context->logging_packet, mag_data);
+  add_mag_blk(context->transmit_buffer, &context->transmit_packet, mag_data);
 }
 
 

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <time.h>
+#include <math.h>
 #include <nuttx/sensors/sensor.h>
 #include <sys/ioctl.h>
 
@@ -241,6 +242,13 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
 }
 
 /**
+ * Convert millibar to pascals
+ */
+static float pascals(float millibar) {
+  return millibar * 100;
+}
+
+/**
  * Add a pressure block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -250,8 +258,15 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
 static void add_pres_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_baro *baro_data) {
   uint8_t *block = alloc_block(buffer, node, DATA_PRESSURE, us_to_ms(baro_data->timestamp));
   if (block) {
-    pres_blk_init((struct pres_blk_t*)block_body(block), baro_data->pressure);
+    pres_blk_init((struct pres_blk_t*)block_body(block), pascals(baro_data->pressure));
   }
+}
+
+/**
+ * Convert a degrees celsius to millidegrees
+ */
+static float millidegrees(float celsius) {
+  return celsius * 1000;
 }
 
 /**
@@ -264,7 +279,7 @@ static void add_pres_blk(packet_buffer_t *buffer, packet_node_t **node, struct s
 static void add_temp_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_baro *baro_data) {
   uint8_t *block = alloc_block(buffer, node, DATA_TEMP, us_to_ms(baro_data->timestamp));
   if (block) {
-    temp_blk_init((struct temp_blk_t*)block_body(block), baro_data->temperature);
+    temp_blk_init((struct temp_blk_t*)block_body(block), millidegrees(baro_data->temperature));
   }
 }
 
@@ -285,6 +300,13 @@ static void baro_handler(void *ctx, uint8_t *data) {
 }
 
 /**
+ * Convert meters per second squared to centimeters per second squared
+ */
+static float cm_per_sec_squared(float meters_per_sec_squared) {
+  return meters_per_sec_squared * 100;
+}
+
+/**
  * Add an acceleration block to the packet being assembled
  * 
  * @param buffer A buffer of packet nodes, in case the current packet can't be added to
@@ -294,7 +316,7 @@ static void baro_handler(void *ctx, uint8_t *data) {
 static void add_accel_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_accel *accel_data) {
   uint8_t *block = alloc_block(buffer, node, DATA_ACCEL_ABS, us_to_ms(accel_data->timestamp));
   if (block) {
-    accel_blk_init((struct accel_blk_t*)block_body(block), accel_data->x, accel_data->y, accel_data->z);
+    accel_blk_init((struct accel_blk_t*)block_body(block), cm_per_sec_squared(accel_data->x), cm_per_sec_squared(accel_data->y), cm_per_sec_squared(accel_data->z));
   }
 }
 
@@ -311,11 +333,99 @@ static void accel_handler(void *ctx, uint8_t *data) {
   add_accel_blk(context->transmit_buffer, &context->transmit_packet, accel_data);
 }
 
+/**
+ * A uorb_data_callback_t function - adds magnetometer data to the required packets
+ *  
+ * @param ctx Context information, type processing_context_t
+ * @param data magnetometer data to add, type struct sensor_mag
+ */
 static void mag_handler(void *ctx, uint8_t *data) {
+  // TODO - currently no definition for magnetometer data in packet spec
 }
 
+
+/**
+ * Convert a radian to a tenth of a degree
+ */
+static float tenth_degree(float radian) {
+  return radian * 18 / M_PI;
+}
+
+/**
+ * Add an gyro block to the packet being assembled
+ * 
+ * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param node The packet currently being assembled
+ * @param gyro_data The gyro data to add
+ */
+static void add_gyro_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gyro *gyro_data) {
+  uint8_t *block = alloc_block(buffer, node, DATA_ANGULAR_VEL, us_to_ms(gyro_data->timestamp));
+  if (block) {
+    ang_vel_blk_init((struct ang_vel_blk_t*)block_body(block), tenth_degree(gyro_data->x), tenth_degree(gyro_data->y), tenth_degree(gyro_data->z));
+  }
+}
+
+/**
+ * A uorb_data_callback_t function - adds gyro data to the required packets
+ *  
+ * @param ctx Context information, type processing_context_t
+ * @param data Acceleration data to add, type struct sensor_gyro
+ */
 static void gyro_handler(void *ctx, uint8_t *data) {
+  struct sensor_gyro *gyro_data = (struct sensor_gyro*)data;
+  processing_context_t *context = (processing_context_t *)ctx;
+  add_gyro_blk(context->logging_buffer, &context->logging_packet, gyro_data);
+  add_gyro_blk(context->transmit_buffer, &context->transmit_packet, gyro_data);
+}
+
+/**
+ * Convert a degree to a tenth of a microdegree
+ */
+static float point_one_microdegrees(float degrees) {
+  return 1E7f * degrees;
+}
+
+/**
+ * Add an gnss block to the packet being assembled
+ * 
+ * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param node The packet currently being assembled
+ * @param gnss_data The gnss data to add
+ */
+static void add_gnss_block(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gnss *gnss_data) {
+  uint8_t *block = alloc_block(buffer, node, DATA_LAT_LONG, us_to_ms(gnss_data->timestamp));
+  if (block) {
+    coord_blk_init((struct coord_blk_t*)block_body(block), point_one_microdegrees(gnss_data->latitude), point_one_microdegrees(gnss_data->longitude));
+  }
+}
+
+/**
+ * Convert meters to millimeters
+ */
+static float millimeters(float meters) {
+  return meters * 1000;
+}
+
+/**
+ * Add a mean sea level altitude block to the packet being assembled
+ * 
+ * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param node The packet currently being assembled
+ * @param alt_data The altitude data to add
+ */
+static void add_msl_block(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gnss *alt_data) {
+  uint8_t *block = alloc_block(buffer, node, DATA_ALT_SEA, us_to_ms(alt_data->timestamp));
+  if (block) {
+    alt_blk_init((struct alt_blk_t*)block_body(block), millimeters(alt_data->altitude));
+  }
 }
 
 static void gnss_handler(void *ctx, uint8_t *data) {
+  struct sensor_gnss *gnss_data = (struct sensor_gnss*)data;
+  processing_context_t *context = (processing_context_t *)ctx;
+  add_gnss_block(context->logging_buffer, &context->logging_packet, gnss_data);
+  add_msl_block(context->logging_buffer, &context->logging_packet, gnss_data);
+
+  add_gnss_block(context->transmit_buffer, &context->transmit_packet, gnss_data);
+  add_msl_block(context->transmit_buffer, &context->transmit_packet, gnss_data);
 }

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -425,6 +425,12 @@ static void add_msl_block(packet_buffer_t *buffer, packet_node_t **node, struct 
   }
 }
 
+/**
+ * A uorb_data_callback_t function - adds gnss data to the required packets
+ *  
+ * @param ctx Context information, type processing_context_t
+ * @param data Acceleration data to add, type struct sensor_gnss
+ */
 static void gnss_handler(void *ctx, uint8_t *data) {
   struct sensor_gnss *gnss_data = (struct sensor_gnss*)data;
   processing_context_t *context = (processing_context_t *)ctx;

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -61,7 +61,7 @@ static void gyro_handler(void *ctx, uint8_t *data);
 
 /* Convert gauss to milligauss */
 
-#define milligauss(gauss) (gauss * 1000)
+#define tenth_microtesla(microtesla) (microtesla * 1000)
 
 /* Convert meters per second squared to centimeters per second squared */
 
@@ -353,7 +353,7 @@ static void accel_handler(void *ctx, uint8_t *data) {
 static void add_mag_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_mag *mag_data) {
   uint8_t *block = alloc_block(buffer, node, DATA_MAGNETIC, us_to_ms(mag_data->timestamp));
   if (block) {
-    mag_blk_init((struct mag_blk_t*)block_body(block), milligauss(mag_data->x), milligauss(mag_data->y), milligauss(mag_data->z));
+    mag_blk_init((struct mag_blk_t*)block_body(block), tenth_microtesla(mag_data->x), tenth_microtesla(mag_data->y), tenth_microtesla(mag_data->z));
   }
 }
 

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -201,4 +201,30 @@ void accel_blk_init(struct accel_blk_t *b, const int16_t x_axis,
   b->y = y_axis;
   b->z = z_axis;
 }
+
+/*
+ * Construct a coordinate block
+ * @param b The coordinate block to initialize
+ * @param lat Latitude of the coordinate, in 0.1 microdegress
+ * @param lon Longitude of the coordinate, in 0.1 microdegress
+ */
+void coord_blk_init(struct coord_blk_t *b, const int32_t lat,
+                    const int32_t lon) {
+  b->latitude = lat;
+  b->longitude = lon;
+}
+
+/*
+ * Construct an angular velocity block
+ * @param b The angular velocity block to initialize
+ * @param x_axis Angular velocity in the x-axis measured in tenths of degrees per second
+ * @param y_axis Angular velocity in the y-axis measured in tenths of degrees per second
+ * @param z_axis Angular velocity in the z-axis measured in tenths of degrees per second
+ */
+void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
+                      const int16_t y_axis, const int16_t z_axis) {
+  b->x = x_axis;
+  b->y = y_axis;
+  b->z = z_axis;
+}
 /* TODO: other block types */

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -156,6 +156,7 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type,
       return NULL;
     }
   }
+  header->blocks++;
   blk_hdr_init((blk_hdr_t *)block, type);
   return block + block_size;
 }
@@ -223,6 +224,20 @@ void coord_blk_init(struct coord_blk_t *b, const int32_t lat,
  */
 void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
                       const int16_t y_axis, const int16_t z_axis) {
+  b->x = x_axis;
+  b->y = y_axis;
+  b->z = z_axis;
+}
+
+/*
+ * Construct a magnetic field block
+ * @param b The magnetic field block to initialize
+ * @param x_axis The magnetic field in the x-axis measured in milligauss
+ * @param y_axis The magnetic field in the y-axis measured in milligauss
+ * @param z_axis The magnetic field in the z-axis measured in milligauss
+ */
+void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis,
+                  const int16_t y_axis, const int16_t z_axis) {
   b->x = x_axis;
   b->y = y_axis;
   b->z = z_axis;

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -19,18 +19,18 @@
 
 /* Possible sub-types of data blocks that can be sent. */
 enum block_type_e {
-  DATA_DBG_MSG = 0x0,    /* Debug message */
-  DATA_ALT_SEA = 0x1,    /* Altitude above sea level */
-  DATA_ALT_LAUNCH = 0x2, /* Altitude above launch level */
-  DATA_TEMP = 0x3,       /* Temperature data */
-  DATA_PRESSURE = 0x4,   /* Pressure data */
-  DATA_ACCEL_REL = 0x5,  /* Relative linear acceleration data */
+  DATA_ALT_SEA = 0x0,    /* Altitude above sea level */
+  DATA_ALT_LAUNCH = 0x1, /* Altitude above launch level */
+  DATA_TEMP = 0x2,       /* Temperature data */
+  DATA_PRESSURE = 0x3,   /* Pressure data */
+  DATA_ACCEL_REL = 0x4,  /* Relative linear acceleration data */
   DATA_ACCEL_ABS =
-      0x6, /* Absolute linear acceleration data (relative to ground) */
-  DATA_ANGULAR_VEL = 0x7, /* Angular velocity data */
-  DATA_HUMIDITY = 0x8,    /* Humidity data */
-  DATA_LAT_LONG = 0x9,    /* Latitude and longitude coordinates */
-  DATA_VOLTAGE = 0xA,     /* Voltage in millivolts with a unique ID. */
+      0x5, /* Absolute linear acceleration data (relative to ground) */
+  DATA_ANGULAR_VEL = 0x6, /* Angular velocity data */
+  DATA_HUMIDITY = 0x7,    /* Humidity data */
+  DATA_LAT_LONG = 0x8,    /* Latitude and longitude coordinates */
+  DATA_VOLTAGE = 0x9,     /* Voltage in millivolts with a unique ID. */
+  DATA_MAGNETIC = 0xA,    /* Magnetic field data */
 };
 
 /* Each radio packet will have a header in this format. */
@@ -122,8 +122,6 @@ struct ang_vel_blk_t {
   /* Angular velocity in the z-axis measured in tenths of degrees per second.
    */
   int16_t z;
-  /* 0 padding to fill the 4 byte multiple requirement of the packet spec. */
-  int16_t _padding;
 };
 
 void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
@@ -142,12 +140,25 @@ struct accel_blk_t {
   /* Linear acceleration in the z-axis measured in centimetres per second
    * squared. */
   int16_t z;
-  /* 0 padding to fill the 4 byte multiple requirement of the packet spec. */
-  int16_t _padding;
 };
 
 void accel_blk_init(struct accel_blk_t *b, const int16_t x_axis,
                     const int16_t y_axis, const int16_t z_axis);
+
+/* A data block containing information about acceleration. */
+struct mag_blk_t {
+  /* The offset from the absolute time in the header in milliseconds */
+  int16_t time_offset;
+  /* Magnetic field in the x-axis measured in milligauss */
+  int16_t x;
+  /* Magnetic field in the y-axis measured in milligauss */
+  int16_t y;
+  /* Magnetic field in the z-axis measured in milligauss */
+  int16_t z;
+};
+
+void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis,
+                  const int16_t y_axis, const int16_t z_axis); 
 
 /* A data block containing latitude and longitude coordinates. */
 struct coord_blk_t {


### PR DESCRIPTION
- Added magnetic, gyro, and gnss data collection and encoding
- Added unit conversions so that transmitted sensor data is accurate
- Used the in-progress changes to the packet specification to add magnetic data, and updated some other packet encoding details that should have been put in earlier (my bad). Namely, the block count in the packet header wasn't being incremented and the block types weren't updated previously to remove the debug block