### PR TITLE
Fix some problems with packets

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -277,7 +277,7 @@ static void baro_handler(void *ctx, uint8_t *data) {
  * @param accel_data The accel data to add
  */
 static void add_accel_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_accel *accel_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_ACCEL_ABS, us_to_ms(accel_data->timestamp));
+  uint8_t *block = alloc_block(buffer, node, DATA_ACCEL_REL, us_to_ms(accel_data->timestamp));
   if (block) {
     accel_blk_init((struct accel_blk_t*)block_body(block), cm_per_sec_squared(accel_data->x), cm_per_sec_squared(accel_data->y), cm_per_sec_squared(accel_data->z));
   }

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -91,8 +91,6 @@ size_t blk_body_len(enum block_type_e type) {
     return sizeof(struct ang_vel_blk_t);
   case DATA_ACCEL_REL:
     return sizeof(struct accel_blk_t);
-  case DATA_ACCEL_ABS:
-    return sizeof(struct accel_blk_t);
   case DATA_ALT_LAUNCH:
     return sizeof(struct alt_blk_t);
   default:
@@ -232,9 +230,9 @@ void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
 /*
  * Construct a magnetic field block
  * @param b The magnetic field block to initialize
- * @param x_axis The magnetic field in the x-axis measured in milligauss
- * @param y_axis The magnetic field in the y-axis measured in milligauss
- * @param z_axis The magnetic field in the z-axis measured in milligauss
+ * @param x_axis The magnetic field in the x-axis measured in 0.1 microtesla
+ * @param y_axis The magnetic field in the y-axis measured in 0.1 microtesla
+ * @param z_axis The magnetic field in the z-axis measured in 0.1 microtesla
  */
 void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis,
                   const int16_t y_axis, const int16_t z_axis) {

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -24,13 +24,11 @@ enum block_type_e {
   DATA_TEMP = 0x2,       /* Temperature data */
   DATA_PRESSURE = 0x3,   /* Pressure data */
   DATA_ACCEL_REL = 0x4,  /* Relative linear acceleration data */
-  DATA_ACCEL_ABS =
-      0x5, /* Absolute linear acceleration data (relative to ground) */
-  DATA_ANGULAR_VEL = 0x6, /* Angular velocity data */
-  DATA_HUMIDITY = 0x7,    /* Humidity data */
-  DATA_LAT_LONG = 0x8,    /* Latitude and longitude coordinates */
-  DATA_VOLTAGE = 0x9,     /* Voltage in millivolts with a unique ID. */
-  DATA_MAGNETIC = 0xA,    /* Magnetic field data */
+  DATA_ANGULAR_VEL = 0x5, /* Angular velocity data */
+  DATA_HUMIDITY = 0x6,    /* Humidity data */
+  DATA_LAT_LONG = 0x7,    /* Latitude and longitude coordinates */
+  DATA_VOLTAGE = 0x8,     /* Voltage in millivolts with a unique ID. */
+  DATA_MAGNETIC = 0x9,    /* Magnetic field data */
 };
 
 /* Each radio packet will have a header in this format. */
@@ -45,7 +43,7 @@ typedef struct {
   uint8_t blocks;
   /* Which number this packet is in the stream of sent packets. */
   uint8_t packet_num;
-} pkt_hdr_t;
+} TIGHTLY_PACKED pkt_hdr_t;
 
 void pkt_hdr_init(pkt_hdr_t *p, uint8_t packet_number, uint32_t mission_time);
 
@@ -53,13 +51,13 @@ void pkt_hdr_init(pkt_hdr_t *p, uint8_t packet_number, uint32_t mission_time);
 typedef struct {
   /* The type of this block. */
   uint8_t type;
-} blk_hdr_t;
+} TIGHTLY_PACKED blk_hdr_t;
 
 /* Base type for blocks with a time offset */
 typedef struct {
   /* The offset from the absolute time in the header in milliseconds */
   int16_t time_offset;
-} offset_blk;
+} TIGHTLY_PACKED offset_blk;
 
 void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
@@ -75,7 +73,7 @@ struct alt_blk_t {
   int16_t time_offset;
   /* Altitude in units of millimetres above/below the launch height. */
   int32_t altitude;
-};
+} TIGHTLY_PACKED;
 
 void alt_blk_init(struct alt_blk_t *b, const int32_t altitude);
 
@@ -85,7 +83,7 @@ struct temp_blk_t {
   int16_t time_offset;
   /* Temperature in millidegrees Celsius. */
   int32_t temperature;
-};
+} TIGHTLY_PACKED;
 
 void temp_blk_init(struct temp_blk_t *b, const int32_t temperature);
 
@@ -95,7 +93,7 @@ struct hum_blk_t {
   int16_t time_offset;
   /* Relative humidity in ten thousandths of a percent. */
   uint32_t humidity;
-};
+} TIGHTLY_PACKED;
 
 void hum_blk_init(struct hum_blk_t *b, const uint32_t humidity);
 
@@ -105,7 +103,7 @@ struct pres_blk_t {
   int16_t time_offset;
   /* Pressure measured in Pascals. */
   uint32_t pressure;
-};
+} TIGHTLY_PACKED;
 
 void pres_blk_init(struct pres_blk_t *b, const int32_t pressure);
 
@@ -122,7 +120,7 @@ struct ang_vel_blk_t {
   /* Angular velocity in the z-axis measured in tenths of degrees per second.
    */
   int16_t z;
-};
+} TIGHTLY_PACKED;
 
 void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
                       const int16_t y_axis, const int16_t z_axis);
@@ -140,22 +138,22 @@ struct accel_blk_t {
   /* Linear acceleration in the z-axis measured in centimetres per second
    * squared. */
   int16_t z;
-};
+} TIGHTLY_PACKED;
 
 void accel_blk_init(struct accel_blk_t *b, const int16_t x_axis,
                     const int16_t y_axis, const int16_t z_axis);
 
 /* A data block containing information about acceleration. */
 struct mag_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
+  /* The offset from the absolute time in the header in 0.1 microtesla */
   int16_t time_offset;
-  /* Magnetic field in the x-axis measured in milligauss */
+  /* Magnetic field in the x-axis measured in 0.1 microtesla */
   int16_t x;
-  /* Magnetic field in the y-axis measured in milligauss */
+  /* Magnetic field in the y-axis measured in 0.1 microtesla */
   int16_t y;
-  /* Magnetic field in the z-axis measured in milligauss */
+  /* Magnetic field in the z-axis measured in 0.1 microtesla */
   int16_t z;
-};
+} TIGHTLY_PACKED;
 
 void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis,
                   const int16_t y_axis, const int16_t z_axis); 
@@ -168,7 +166,7 @@ struct coord_blk_t {
   int32_t latitude;
   /* Longitude in 0.1 microdegrees/LSB. */
   int32_t longitude;
-};
+} TIGHTLY_PACKED;
 
 void coord_blk_init(struct coord_blk_t *b, const int32_t lat,
                     const int32_t lon);
@@ -182,7 +180,7 @@ struct volt_blk_t {
   uint16_t id;
   /* Voltage in millivolts. */
   int16_t voltage;
-};
+} TIGHTLY_PACKED;
 
 void volt_blk_init(struct volt_blk_t *b, const uint16_t id,
                    const int16_t voltage);


### PR DESCRIPTION
* Tightly packed attribute might have been removed by me accidentally - the added padding was breaking parsing. With the attribute added back the parsing works fine.
* Enum values weren't the same as in the packet spec which has been corrected