### PR TITLE
Add altitude fusion

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -411,4 +411,5 @@ static void alt_handler(void *ctx, uint8_t *data) {
   struct fusion_altitude *alt_data = (struct fusion_altitude*)data;
   processing_context_t *context = (processing_context_t *)ctx;
   add_msl_block(context->logging_buffer, &context->logging_packet, alt_data);
+  add_msl_block(context->transmit_buffer, &context->transmit_packet, alt_data);
 }

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include <nuttx/sensors/sensor.h>
 #include <sys/ioctl.h>
+#include <math.h>
 
 #include "../sensors/sensors.h"
 #include "fusion.h"

--- a/telemetry/src/fusion/fusion.h
+++ b/telemetry/src/fusion/fusion.h
@@ -4,15 +4,18 @@
 #include <uORB/uORB.h>
 
 /* UORB declarations for fused sensor data */
-ORB_DECLARE(fusion_accel);
-ORB_DECLARE(fusion_baro);
+ORB_DECLARE(fusion_altitude);
 
 /* 
  * Size of the internal queues for the fusioned data, which other threads should 
  * match the size of their buffers to 
  */
-#define ACCEL_FUSION_BUFFER_SIZE 100
-#define BARO_FUSION_BUFFER_SIZE 100
+#define ACCEL_FUSION_BUFFER_SIZE 5
+
+struct fusion_altitude {
+  uint64_t timestamp;
+  float altitude;
+};
 
 #endif // _FUSION_H_
 

--- a/telemetry/src/fusion/fusion.h
+++ b/telemetry/src/fusion/fusion.h
@@ -10,7 +10,7 @@ ORB_DECLARE(fusion_altitude);
  * Size of the internal queues for the fusioned data, which other threads should 
  * match the size of their buffers to 
  */
-#define ACCEL_FUSION_BUFFER_SIZE 5
+#define ALT_FUSION_BUFFER 5
 
 struct fusion_altitude {
   uint64_t timestamp;

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -79,24 +79,31 @@ void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type) {
  */
 size_t blk_body_len(enum block_type_e type) {
   switch (type) {
-  case DATA_TEMP:
-    return sizeof(struct temp_blk_t);
-  case DATA_HUMIDITY:
-    return sizeof(struct hum_blk_t);
-  case DATA_VOLTAGE:
-    return sizeof(struct volt_blk_t);
-  case DATA_LAT_LONG:
-    return sizeof(struct coord_blk_t);
-  case DATA_PRESSURE:
-    return sizeof(struct pres_blk_t);
-  case DATA_ANGULAR_VEL:
-    return sizeof(struct ang_vel_blk_t);
-  case DATA_ACCEL_REL:
-    return sizeof(struct accel_blk_t);
+  case DATA_ALT_SEA:
+    return sizeof(struct alt_blk_t);
   case DATA_ALT_LAUNCH:
     return sizeof(struct alt_blk_t);
+  case DATA_TEMP:
+    return sizeof(struct temp_blk_t);
+  case DATA_PRESSURE:
+    return sizeof(struct pres_blk_t);
+  case DATA_ACCEL_REL:
+    return sizeof(struct accel_blk_t);
+  case DATA_ANGULAR_VEL:
+    return sizeof(struct ang_vel_blk_t);
+  case DATA_HUMIDITY:
+    return sizeof(struct hum_blk_t);
+  case DATA_LAT_LONG:
+    return sizeof(struct coord_blk_t);
+  case DATA_VOLTAGE:
+    return sizeof(struct volt_blk_t);
+  case DATA_MAGNETIC:
+    return sizeof(struct mag_blk_t);
   default:
-    return 0;
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Length requested for unsupported type %d\n", type);
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    return -1;
   }
 }
 

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -55,10 +55,15 @@ static int has_offset(enum block_type_e type) {
  * transmissions.
  */
 void pkt_hdr_init(pkt_hdr_t *p, uint8_t packet_number, uint32_t mission_time) {
-  if (sizeof(CONFIG_INSPACE_TELEMETRY_CALLSIGN) < sizeof(p->call_sign)) {
-    memset(&p->call_sign, '0', sizeof(p->call_sign));
+  // Don't include the null-terminator
+  int callsign_length = sizeof(CONFIG_INSPACE_TELEMETRY_CALLSIGN) - 1;
+  if (callsign_length < sizeof(p->call_sign)) {
+    memcpy(&p->call_sign, CONFIG_INSPACE_TELEMETRY_CALLSIGN, callsign_length);
+    memset(&p->call_sign[callsign_length], '0', sizeof(p->call_sign) - callsign_length);
+  } else {
+    memcpy(&p->call_sign, CONFIG_INSPACE_TELEMETRY_CALLSIGN, sizeof(p->call_sign));
   }
-  strncpy(&p->call_sign, CONFIG_INSPACE_TELEMETRY_CALLSIGN, sizeof(p->call_sign));
+
   p->packet_num = packet_number;
   p->timestamp = calc_timestamp(mission_time);
   p->blocks = 0;

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -55,8 +55,10 @@ static int has_offset(enum block_type_e type) {
  * transmissions.
  */
 void pkt_hdr_init(pkt_hdr_t *p, uint8_t packet_number, uint32_t mission_time) {
-  memcpy(&p->call_sign, CONFIG_INSPACE_TELEMETRY_CALLSIGN,
-         sizeof(CONFIG_INSPACE_TELEMETRY_CALLSIGN));
+  if (sizeof(CONFIG_INSPACE_TELEMETRY_CALLSIGN) < sizeof(p->call_sign)) {
+    memset(&p->call_sign, '0', sizeof(p->call_sign));
+  }
+  strncpy(&p->call_sign, CONFIG_INSPACE_TELEMETRY_CALLSIGN, sizeof(p->call_sign));
   p->packet_num = packet_number;
   p->timestamp = calc_timestamp(mission_time);
   p->blocks = 0;

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -4,6 +4,8 @@
 #include <uORB/uORB.h>
 #include <poll.h>
 
+#include "../fusion/fusion.h"
+
 /* Used for polling on multiple sensors at once. Don't set up the ones you don't want to use */
 struct uorb_inputs {
   struct pollfd accel;
@@ -11,6 +13,7 @@ struct uorb_inputs {
   struct pollfd mag;
   struct pollfd gyro;
   struct pollfd gnss;
+  struct pollfd alt;
 };
 
 /* A buffer that can hold any of the types of data created by the sensors in uorb_inputs */
@@ -20,6 +23,7 @@ union uorb_data {
   struct sensor_mag mag;
   struct sensor_gyro gyro;
   struct sensor_gnss gnss;
+  struct fusion_altitude alt;
 };
 
 /* The numbers of sensors defined in uorb_inputs */


### PR DESCRIPTION
- Added fusion for calculating sea level altitude. We can get the relative altitude by either processing the logged data (which might be the best option, since we don't need to worry about setting the pressure mid-flight and messing up our readings accidentally)