### PR TITLE
Add way to limit amount of a type of block in packets

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -36,6 +36,7 @@ typedef struct {
 
 static int setup_collection(collection_info_t *collection, packet_buffer_t *packet_buffer);
 static void reset_block_count(collection_info_t *collection);
+static void print_block_count(collection_info_t *collection);
 static uint8_t *add_block(collection_info_t *collection, enum block_type_e type, uint32_t mission_time);
 static uint8_t *add_or_new(collection_info_t *collection, enum block_type_e type, uint32_t mission_time);
 static void baro_handler(void *ctx, uint8_t *data);
@@ -44,6 +45,11 @@ static void mag_handler(void *ctx, uint8_t *data);
 static void gnss_handler(void *ctx, uint8_t *data);
 static void gyro_handler(void *ctx, uint8_t *data);
 static void alt_handler(void *ctx, uint8_t *data);
+
+/* Don't use this function if debug printing is off */
+#if !defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+#define print_block_count(collection)
+#endif /* CONFIG_INSPACE_TELEMETRY_DEBUG */
 
 /* Convert microseconds to milliseconds */
 
@@ -233,11 +239,9 @@ static void reset_block_count(collection_info_t *collection) {
  * @param collection Information about collected data
  */
 static void print_block_count(collection_info_t *collection) {
-#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
   for (int i = 0; i < sizeof(collection->block_count) / sizeof(collection->block_count[0]); i++) {
     printf("Count for %02x: %d\n", i, collection->block_count[i]);
   }
-#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 }
 
 /**

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -24,14 +24,19 @@
 #define err_to_ptr(err) ((void *)((err)))
 
 typedef struct {
-  packet_buffer_t *logging_buffer;
-  packet_node_t *logging_packet;
+  packet_buffer_t *buffer;
+  packet_node_t *current;
+  int block_count[DATA_RES_ABOVE];
+} collection_info_t;
 
-  packet_buffer_t *transmit_buffer;
-  packet_node_t *transmit_packet;
+typedef struct {
+  collection_info_t logging;
+  collection_info_t transmit;
 } processing_context_t;
 
-static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum block_type_e type, uint32_t mission_time);
+static int setup_collection(collection_info_t *collection, packet_buffer_t *packet_buffer);
+static uint8_t *add_block(collection_info_t *collection, enum block_type_e type, uint32_t mission_time);
+static uint8_t *add_or_new(collection_info_t *collection, enum block_type_e type, uint32_t mission_time);
 static void baro_handler(void *ctx, uint8_t *data);
 static void accel_handler(void *ctx, uint8_t *data);
 static void mag_handler(void *ctx, uint8_t *data);
@@ -94,15 +99,19 @@ void *collection_main(void *arg) {
   rocket_state_t *state = unpacked_args->state;
 
   processing_context_t context;
-  context.logging_buffer = unpacked_args->logging_buffer;
-  context.logging_packet = packet_buffer_get_empty(context.logging_buffer);
-  context.transmit_buffer = unpacked_args->transmit_buffer;
-  context.transmit_packet = packet_buffer_get_empty(context.transmit_buffer);
-  if (!context.logging_packet || !context.transmit_packet) {
+  err = setup_collection(&context.logging, unpacked_args->logging_buffer);
+  if (err < 0) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
     fprintf(stderr, "Could not get an initial empty packet for collection\n");
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
-    pthread_exit(err_to_ptr(-ENOMEM));
+    pthread_exit(err_to_ptr(err));
+  }
+  err = setup_collection(&context.transmit, unpacked_args->transmit_buffer);
+  if (err < 0) {
+#if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
+    fprintf(stderr, "Could not get an initial empty packet for collection\n");
+#endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
+    pthread_exit(err_to_ptr(err));
   }
 
   struct uorb_inputs sensors;
@@ -191,25 +200,56 @@ void *collection_main(void *arg) {
 }
 
 /**
- * Allocates a block in the current node or a block in a new node if the current node is full
+ * Sets up a collection_info_t struct with a packet buffer and gets an initially empty node to work on
  * 
- * @param buffer The buffer to get a new, empty node from and place full nodes in
- * @param node The current node being worked on
+ * @param collection The collection_info_t struct to set up
+ * @param packet_buffer The buffer to get packets from a put into
+ * @return 0 on success, or a negative error code on failure
+ */
+static int setup_collection(collection_info_t *collection, packet_buffer_t *packet_buffer) {
+  collection->buffer = packet_buffer;
+  collection->current = packet_buffer_get_empty(packet_buffer);
+  if (!collection->current) {
+    return -1; 
+  }
+  return 0;
+}
+
+/**
+ * Adds a block to the current packet being worked on
+ *
+ * @param collection The buffer to add the block to
+ * @param type The type of block to add
+ * @param mission_time The time of measurement for the block, if it has one
+ * @return The location to write the block, or NULL if the block could not be added
+ */
+static uint8_t *add_block(collection_info_t *collection, enum block_type_e type, uint32_t mission_time) {
+  uint8_t *block = pkt_create_blk(collection->current->packet, collection->current->end, type, mission_time);
+  if (block) {
+    collection->block_count[type]++;
+  }
+  return block;
+}
+
+/**
+ * Allocates a block in the current packet or swaps out the current packet if the block can't be added
+ * 
+ * @param collection Collection information
  * @param type The type of block being allocated
  * @param mission_time The time of the measurement, if this block type has one
  * @return The location to write the requested type of block
  */
-static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum block_type_e type, uint32_t mission_time) {
+static uint8_t *add_or_new(collection_info_t *collection, enum block_type_e type, uint32_t mission_time) {
   // The last byte of the packet will be where the block is allocated, but we need to know where it will end to update (*node)->end
-  uint8_t *next_block = pkt_create_blk((*node)->packet, (*node)->end, type, mission_time);
+  uint8_t *next_block = add_block(collection, type, mission_time);
   // Can't add to this packet, it's full or we can just assume its done being asssembled
   if (next_block == NULL) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
-    printf("Completed a packet length %ld\n", (*node)->end - (*node)->packet);
+    printf("Completed a packet length %ld\n", collection->current->end - collection->current->packet);
 #endif
-    packet_buffer_put_full(buffer, *node);
-    (*node) = packet_buffer_get_empty(buffer);
-    if (*node == NULL) {
+    packet_buffer_put_full(collection->buffer, collection->current);
+    collection->current = packet_buffer_get_empty(collection->buffer);
+    if (collection->current == NULL) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
       fprintf(stderr, "Couldn't get an empty packet or overwrite a full one - not enough packets in buffer\n");
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
@@ -217,8 +257,8 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
     }
 
     // Leave seq num up to the logger/transmitter (don't know if or in what order packets get transmitted)
-    (*node)->end = init_pkt((*node)->packet, 0, mission_time);
-    next_block = pkt_create_blk((*node)->packet, (*node)->end, type, mission_time);
+    collection->current->end = init_pkt(collection->current->packet, 0, mission_time);
+    next_block = pkt_create_blk(collection->current->packet, collection->current->end, type, mission_time);
     if (next_block == NULL) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
       fprintf(stderr, "Couldn't add a block to a new packet\n");
@@ -226,8 +266,8 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
       return NULL;
     }
   }
-  uint8_t *write_to = (*node)->end;
-  (*node)->end = next_block;
+  uint8_t *write_to = collection->current->end;
+  collection->current->end = next_block;
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
   //printf("Allocated %ld bytes for type %d in packet %p, current size %ld\n", next_block - write_to, type, (*node)->packet, (*node)->end - (*node)->packet);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
@@ -237,12 +277,12 @@ static uint8_t *alloc_block(packet_buffer_t *buffer, packet_node_t **node, enum 
 /**
  * Add a pressure block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param baro_data The baro data to add
  */
-static void add_pres_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_baro *baro_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_PRESSURE, us_to_ms(baro_data->timestamp));
+static void add_pres_blk(collection_info_t *collection, struct sensor_baro *baro_data) {
+  uint8_t *block = add_or_new(collection, DATA_PRESSURE, us_to_ms(baro_data->timestamp));
   if (block) {
     pres_blk_init((struct pres_blk_t*)block_body(block), pascals(baro_data->pressure));
   }
@@ -251,12 +291,12 @@ static void add_pres_blk(packet_buffer_t *buffer, packet_node_t **node, struct s
 /**
  * Add a temperature block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param baro_data The baro data to add
  */
-static void add_temp_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_baro *baro_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_TEMP, us_to_ms(baro_data->timestamp));
+static void add_temp_blk(collection_info_t *collection, struct sensor_baro *baro_data) {
+  uint8_t *block = add_or_new(collection, DATA_TEMP, us_to_ms(baro_data->timestamp));
   if (block) {
     temp_blk_init((struct temp_blk_t*)block_body(block), millidegrees(baro_data->temperature));
   }
@@ -271,22 +311,22 @@ static void add_temp_blk(packet_buffer_t *buffer, packet_node_t **node, struct s
 static void baro_handler(void *ctx, uint8_t *data) {
   struct sensor_baro *baro_data = (struct sensor_baro*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_pres_blk(context->logging_buffer, &context->logging_packet, baro_data);
-  add_temp_blk(context->logging_buffer, &context->logging_packet, baro_data);
+  add_pres_blk(&context->logging, baro_data);
+  add_temp_blk(&context->logging, baro_data);
 
-  add_pres_blk(context->transmit_buffer, &context->transmit_packet, baro_data);
-  add_temp_blk(context->transmit_buffer, &context->transmit_packet, baro_data);
+  add_pres_blk(&context->transmit, baro_data);
+  add_temp_blk(&context->transmit, baro_data);
 }
 
 /**
  * Add an acceleration block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param accel_data The accel data to add
  */
-static void add_accel_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_accel *accel_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_ACCEL_REL, us_to_ms(accel_data->timestamp));
+static void add_accel_blk(collection_info_t *collection, struct sensor_accel *accel_data) {
+  uint8_t *block = add_or_new(collection, DATA_ACCEL_REL, us_to_ms(accel_data->timestamp));
   if (block) {
     accel_blk_init((struct accel_blk_t*)block_body(block), cm_per_sec_squared(accel_data->x), cm_per_sec_squared(accel_data->y), cm_per_sec_squared(accel_data->z));
   }
@@ -301,19 +341,19 @@ static void add_accel_blk(packet_buffer_t *buffer, packet_node_t **node, struct 
 static void accel_handler(void *ctx, uint8_t *data) {
   struct sensor_accel *accel_data = (struct sensor_accel*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_accel_blk(context->logging_buffer, &context->logging_packet, accel_data);
-  add_accel_blk(context->transmit_buffer, &context->transmit_packet, accel_data);
+  add_accel_blk(&context->logging, accel_data);
+  add_accel_blk(&context->transmit, accel_data);
 }
 
 /**
  * Add a magnetometer block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param mag_data The magnetic field data to add
  */
-static void add_mag_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_mag *mag_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_MAGNETIC, us_to_ms(mag_data->timestamp));
+static void add_mag_blk(collection_info_t *collection, struct sensor_mag *mag_data) {
+  uint8_t *block = add_or_new(collection, DATA_MAGNETIC, us_to_ms(mag_data->timestamp));
   if (block) {
     mag_blk_init((struct mag_blk_t*)block_body(block), tenth_microtesla(mag_data->x), tenth_microtesla(mag_data->y), tenth_microtesla(mag_data->z));
   }
@@ -328,19 +368,19 @@ static void add_mag_blk(packet_buffer_t *buffer, packet_node_t **node, struct se
 static void mag_handler(void *ctx, uint8_t *data) {
   struct sensor_mag *mag_data = (struct sensor_mag*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_mag_blk(context->logging_buffer, &context->logging_packet, mag_data);
-  add_mag_blk(context->transmit_buffer, &context->transmit_packet, mag_data);
+  add_mag_blk(&context->logging, mag_data);
+  add_mag_blk(&context->transmit, mag_data);
 }
 
 /**
  * Add an gyro block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param gyro_data The gyro data to add
  */
-static void add_gyro_blk(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gyro *gyro_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_ANGULAR_VEL, us_to_ms(gyro_data->timestamp));
+static void add_gyro_blk(collection_info_t *collection, struct sensor_gyro *gyro_data) {
+  uint8_t *block = add_or_new(collection, DATA_ANGULAR_VEL, us_to_ms(gyro_data->timestamp));
   if (block) {
     ang_vel_blk_init((struct ang_vel_blk_t*)block_body(block), tenth_degree(gyro_data->x), tenth_degree(gyro_data->y), tenth_degree(gyro_data->z));
   }
@@ -355,19 +395,19 @@ static void add_gyro_blk(packet_buffer_t *buffer, packet_node_t **node, struct s
 static void gyro_handler(void *ctx, uint8_t *data) {
   struct sensor_gyro *gyro_data = (struct sensor_gyro*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_gyro_blk(context->logging_buffer, &context->logging_packet, gyro_data);
-  add_gyro_blk(context->transmit_buffer, &context->transmit_packet, gyro_data);
+  add_gyro_blk(&context->logging, gyro_data);
+  add_gyro_blk(&context->transmit, gyro_data);
 }
 
 /**
  * Add an gnss block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param gnss_data The gnss data to add
  */
-static void add_gnss_block(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gnss *gnss_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_LAT_LONG, us_to_ms(gnss_data->timestamp));
+static void add_gnss_block(collection_info_t *collection, struct sensor_gnss *gnss_data) {
+  uint8_t *block = add_or_new(collection, DATA_LAT_LONG, us_to_ms(gnss_data->timestamp));
   if (block) {
     coord_blk_init((struct coord_blk_t*)block_body(block), point_one_microdegrees(gnss_data->latitude), point_one_microdegrees(gnss_data->longitude));
   }
@@ -376,12 +416,12 @@ static void add_gnss_block(packet_buffer_t *buffer, packet_node_t **node, struct
 /**
  * Add a gnss mean sea level altitude block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param alt_data The altitude data to add
  */
-static void add_gnss_msl_block(packet_buffer_t *buffer, packet_node_t **node, struct sensor_gnss *alt_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_ALT_SEA, us_to_ms(alt_data->timestamp));
+static void add_gnss_msl_block(collection_info_t *collection, struct sensor_gnss *alt_data) {
+  uint8_t *block = add_or_new(collection, DATA_ALT_SEA, us_to_ms(alt_data->timestamp));
   if (block) {
     alt_blk_init((struct alt_blk_t*)block_body(block), millimeters(alt_data->altitude));
   }
@@ -390,12 +430,12 @@ static void add_gnss_msl_block(packet_buffer_t *buffer, packet_node_t **node, st
 /**
  * Add a mean sea level altitude block to the packet being assembled
  * 
- * @param buffer A buffer of packet nodes, in case the current packet can't be added to
+ * @param collection A buffer of packet nodes, in case the current packet can't be added to
  * @param node The packet currently being assembled
  * @param alt_data The altitude data to add
  */
-static void add_msl_block(packet_buffer_t *buffer, packet_node_t **node, struct fusion_altitude *alt_data) {
-  uint8_t *block = alloc_block(buffer, node, DATA_ALT_SEA, us_to_ms(alt_data->timestamp));
+static void add_msl_block(collection_info_t *collection, struct fusion_altitude *alt_data) {
+  uint8_t *block = add_or_new(collection, DATA_ALT_SEA, us_to_ms(alt_data->timestamp));
   if (block) {
     alt_blk_init((struct alt_blk_t*)block_body(block), millimeters(alt_data->altitude));
   }
@@ -410,11 +450,11 @@ static void add_msl_block(packet_buffer_t *buffer, packet_node_t **node, struct 
 static void gnss_handler(void *ctx, uint8_t *data) {
   struct sensor_gnss *gnss_data = (struct sensor_gnss*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_gnss_block(context->logging_buffer, &context->logging_packet, gnss_data);
-  add_gnss_msl_block(context->logging_buffer, &context->logging_packet, gnss_data);
+  add_gnss_block(&context->logging, gnss_data);
+  add_gnss_msl_block(&context->logging, gnss_data);
 
-  add_gnss_block(context->transmit_buffer, &context->transmit_packet, gnss_data);
-  add_gnss_msl_block(context->transmit_buffer, &context->transmit_packet, gnss_data);
+  add_gnss_block(&context->transmit, gnss_data);
+  add_gnss_msl_block(&context->transmit, gnss_data);
 }
 
 /**
@@ -426,6 +466,6 @@ static void gnss_handler(void *ctx, uint8_t *data) {
 static void alt_handler(void *ctx, uint8_t *data) {
   struct fusion_altitude *alt_data = (struct fusion_altitude*)data;
   processing_context_t *context = (processing_context_t *)ctx;
-  add_msl_block(context->logging_buffer, &context->logging_packet, alt_data);
-  add_msl_block(context->transmit_buffer, &context->transmit_packet, alt_data);
+  add_msl_block(&context->logging, alt_data);
+  add_msl_block(&context->transmit, alt_data);
 }

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -34,7 +34,7 @@
 static const char fusion_alt_format[] = "fusioned altitude - timestamp:%" PRIu64 ",altitude:%hf";
 ORB_DEFINE(fusion_altitude, struct fusion_altitude, fusion_alt_format);
 #else
-ORB_DEFINE(fusion_altitude, struct fusion_altitude);
+ORB_DEFINE(fusion_altitude, struct fusion_altitude, 0);
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */
 
 /* Buffers for inputs, best to match to the size of the internal sensor buffers */

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -162,7 +162,6 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
 #if defined(PACKET_BUFFERING_DEBUG)
     printf("Got an packet from the buffer at address %p to write into\n", packet); 
 #endif /* defined(PACKET_BUFFERING_DEBUG) */
-    // Take from the end, since that should be the oldest packet
     return packet;
 }
 

--- a/telemetry/src/packets/buffering.h
+++ b/telemetry/src/packets/buffering.h
@@ -2,6 +2,7 @@
 #define _INSPACE_PACKET_QUEUE_H_
 
 #include <pthread.h>
+
 #include "packets.h"
 
 typedef struct packet_node packet_node_t;

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -49,6 +49,14 @@ static int has_offset(enum block_type_e type) {
   }
 }
 
+/* Get the timestamp out of a block body
+ * @param block_body The body of the block to get a timestamp from
+ * @return A the timestamp field of the block
+ */
+static int16_t *block_timestamp(uint8_t* block_body) {
+  return (int16_t *)(block_body);
+}
+
 /* Initialize the packet header.
  * @param p The packet header to initialize.
  * @param packet_number The sequence number of this packet in the stream of
@@ -161,7 +169,7 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type,
     return NULL;
   }
   if (has_offset(type)) {
-    if (calc_offset(mission_time, header->timestamp, &((offset_blk *)block_body(block))->time_offset)) {
+    if (calc_offset(mission_time, header->timestamp, block_timestamp(block_body(block)))) {
 #if defined(CONFIG_INSPACE_TELEMETRY_DEBUG)
       /*fprintf(stderr, "Could not fit time into packet, time was %d and packet header had %d\n", mission_time, 30000 * header->timestamp );*/
 #endif /* defined(CONFIG_INSPACE_TELEMETRY_DEBUG) */

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -19,16 +19,17 @@
 
 /* Possible sub-types of data blocks that can be sent. */
 enum block_type_e {
-  DATA_ALT_SEA = 0x0,    /* Altitude above sea level */
-  DATA_ALT_LAUNCH = 0x1, /* Altitude above launch level */
-  DATA_TEMP = 0x2,       /* Temperature data */
-  DATA_PRESSURE = 0x3,   /* Pressure data */
-  DATA_ACCEL_REL = 0x4,  /* Relative linear acceleration data */
+  DATA_ALT_SEA = 0x0,     /* Altitude above sea level */
+  DATA_ALT_LAUNCH = 0x1,  /* Altitude above launch level */
+  DATA_TEMP = 0x2,        /* Temperature data */
+  DATA_PRESSURE = 0x3,    /* Pressure data */
+  DATA_ACCEL_REL = 0x4,   /* Relative linear acceleration data */
   DATA_ANGULAR_VEL = 0x5, /* Angular velocity data */
   DATA_HUMIDITY = 0x6,    /* Humidity data */
   DATA_LAT_LONG = 0x7,    /* Latitude and longitude coordinates */
   DATA_VOLTAGE = 0x8,     /* Voltage in millivolts with a unique ID. */
   DATA_MAGNETIC = 0x9,    /* Magnetic field data */
+  DATA_RES_ABOVE = 0xA,   /* Types unused above this value */
 };
 
 /* Each radio packet will have a header in this format. */

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -53,12 +53,6 @@ typedef struct {
   uint8_t type;
 } TIGHTLY_PACKED blk_hdr_t;
 
-/* Base type for blocks with a time offset */
-typedef struct {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-} TIGHTLY_PACKED offset_blk;
-
 void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
 
 size_t blk_body_len(enum block_type_e type);

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -49,7 +49,7 @@ int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
  * @param size The size of the data parameter in bytes
  * @return The number of bytes read from the sensor or 0 if there was none to read
  */
-ssize_t get_sensor_data(struct pollfd *sensor, uint8_t *data, size_t size) {
+ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
  /*
   * If the sensor wasn't set up right, POLLIN won't get set, meaning there's no need to avoid using
   * the sensor if its metadata or fd weren't set up properly
@@ -79,7 +79,7 @@ ssize_t get_sensor_data(struct pollfd *sensor, uint8_t *data, size_t size) {
  * @param size The size of the data parameter in bytes
  * @return The 
  */
-uint8_t *get_sensor_data_end(struct pollfd *sensor, uint8_t* data, size_t size) {
+void *get_sensor_data_end(struct pollfd *sensor, void* data, size_t size) {
   return data + get_sensor_data(sensor, data, size);
 }
 
@@ -115,9 +115,9 @@ void poll_sensors(struct uorb_inputs *sensors) {
  * @param len The number of bytes of data in the buffer
  * @param elem_size The size of each element in the data buffer
  */
-void foreach_measurement(uorb_data_callback_t handler, void* handler_context, uint8_t *buf, size_t len, size_t elem_size) {
+void foreach_measurement(uorb_data_callback_t handler, void* handler_context, void *data, size_t len, size_t elem_size) {
   for (int i = 0; i < (len / elem_size); i++) {
-    handler(handler_context, buf + (i * elem_size));
+    handler(handler_context, data + (i * elem_size));
   }
 }
 
@@ -131,7 +131,7 @@ void foreach_measurement(uorb_data_callback_t handler, void* handler_context, ui
  * @param elem_size The size of elements in the buffer
  * @return 1 if a piece of data was processed, 0 otherwise
  */
-int process_one(uorb_data_callback_t handler, void* handler_context, uint8_t **data_start, uint8_t *data_end, size_t elem_size) {
+int process_one(uorb_data_callback_t handler, void* handler_context, void **data_start, void *data_end, size_t elem_size) {
   if ((*data_start == data_end) || ((elem_size + *data_start) > data_end)) {
     return 0;
   }

--- a/telemetry/src/sensors/sensors.h
+++ b/telemetry/src/sensors/sensors.h
@@ -38,11 +38,11 @@ union uorb_data {
 typedef void (*uorb_data_callback_t)(void* context, uint8_t* element);
 
 int setup_sensor(struct pollfd *sensor, orb_id_t meta);
-ssize_t get_sensor_data(struct pollfd *sensor, uint8_t *data, size_t size);
-uint8_t *get_sensor_data_end(struct pollfd *sensor, uint8_t* data, size_t size);
+ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size);
+void *get_sensor_data_end(struct pollfd *sensor, void* data, size_t size);
 void clear_uorb_inputs(struct uorb_inputs *sensors);
 void poll_sensors(struct uorb_inputs *sensors);
-void foreach_measurement(uorb_data_callback_t handler, void* handler_context, uint8_t *buf, size_t size, size_t elem_size);
-int process_one(uorb_data_callback_t handler, void* handler_context, uint8_t **data_start, uint8_t *data_end, size_t elem_size);
+void foreach_measurement(uorb_data_callback_t handler, void* handler_context, void *data, size_t size, size_t elem_size);
+int process_one(uorb_data_callback_t handler, void* handler_context, void **data_start, void *data_end, size_t elem_size);
 
 #endif // _INSPACE_SENSORS_H_


### PR DESCRIPTION
- Added a limit on pressure and temperature data being added to transmit packets (which could be adjusted to suit our needs) so that more important data gets added instead. Currently the limit is set to five measurements per packet
- Also suppressed some warnings by changing types around