### PR TITLE
Add check for gps fix before sending out block

### DIFF
--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -484,6 +484,8 @@ static void add_msl_block(collection_info_t *collection, struct fusion_altitude 
 static void gnss_handler(void *ctx, uint8_t *data) {
   struct sensor_gnss *gnss_data = (struct sensor_gnss*)data;
   processing_context_t *context = (processing_context_t *)ctx;
+  if (gnss_data->latitude == (int)NULL && gnss_data->longitude == (int)NULL) return; // Don't send packets with no sat fix
+
   add_gnss_block(&context->logging, gnss_data);
   add_gnss_msl_block(&context->logging, gnss_data);
 


### PR DESCRIPTION
This PR adds a check in the gnss_handler function such that packets with no latitude and longitude fix are not prepared and are not sent over the radio