### PR TITLE
Fix circbuf usage and related tests

### DIFF
--- a/telemetry/src/fusion/detector.c
+++ b/telemetry/src/fusion/detector.c
@@ -111,12 +111,12 @@ static int detector_is_apogee(struct detector *detector) {
  */
 void detector_init(struct detector *detector, uint64_t time) {
     median_filter_init(&detector->alts.median, detector->alts.median_backing_sorted,
-                       detector->alts.median_backing_time_ordered, ALTITUDE_MEDIAN_FILTER_SIZE);
-    average_filter_init(&detector->alts.average, detector->alts.average_backing, ALTITUDE_AVERAGE_FILTER_SIZE);
+                       detector->alts.median_backing_time_ordered, sizeof(detector->alts.median_backing_sorted));
+    average_filter_init(&detector->alts.average, detector->alts.average_backing, sizeof(detector->alts.average_backing));
 
     median_filter_init(&detector->accels.median, detector->accels.median_backing_sorted,
-                       detector->accels.median_backing_time_ordered, ACCEL_MEDIAN_FILTER_SIZE);
-    average_filter_init(&detector->accels.average, detector->accels.average_backing, ACCEL_AVERAGE_FILTER_SIZE);
+                       detector->accels.median_backing_time_ordered, sizeof(detector->accels.median_backing_sorted));
+    average_filter_init(&detector->accels.average, detector->accels.average_backing, sizeof(detector->accels.average_backing));
 
     window_criteria_init(&detector->alt_window, LANDED_ALT_WINDOW_SIZE, LANDED_ALT_WINDOW_DURATION);
 

--- a/telemetry/src/fusion/filtering.c
+++ b/telemetry/src/fusion/filtering.c
@@ -20,8 +20,8 @@ static int circbuf_push_out(struct circbuf_s *circ, void *new, void *old, size_t
 
     /* If here, the circular buffer was full. Read the oldest data */
 
-    circbuf_read(circ, old, size);
-    circbuf_write(circ, new, size);
+    circbuf_peekat(circ, 0, old, size);
+    circbuf_overwrite(circ, new, size);
     return 1;
 }
 
@@ -125,7 +125,7 @@ float average_filter_add(struct average_filter *filter, float new_value) {
         filter->sum -= old_value;
     }
     filter->sum += new_value;
-    return filter->sum / (circbuf_size(&filter->buffer) / sizeof(float));
+    return filter->sum / (circbuf_used(&filter->buffer) / sizeof(float));
 }
 
 /**

--- a/tests/test_filtering.c
+++ b/tests/test_filtering.c
@@ -15,7 +15,7 @@ static void test_median_filter_single_value__returns_value(void) {
     float sorted[TEST_FILTER_SIZE];
     float time_ordered[TEST_FILTER_SIZE];
 
-    median_filter_init(&filter, sorted, time_ordered, TEST_FILTER_SIZE);
+    median_filter_init(&filter, sorted, time_ordered, sizeof(sorted));
 
     float result = median_filter_add(&filter, 5.0f);
     TEST_ASSERT_EQUAL_FLOAT_MESSAGE(5.0f, result, "Single value should be returned as median");
@@ -26,7 +26,7 @@ static void test_median_filter_odd_values__returns_middle_value(void) {
     float sorted[TEST_FILTER_SIZE];
     float time_ordered[TEST_FILTER_SIZE];
 
-    median_filter_init(&filter, sorted, time_ordered, TEST_FILTER_SIZE);
+    median_filter_init(&filter, sorted, time_ordered, sizeof(sorted));
 
     median_filter_add(&filter, 3.0f);
     median_filter_add(&filter, 1.0f);
@@ -42,7 +42,7 @@ static void test_median_filter_overflow__oldest_value_removed(void) {
     float sorted[3];
     float time_ordered[3];
 
-    median_filter_init(&filter, sorted, time_ordered, 3);
+    median_filter_init(&filter, sorted, time_ordered, sizeof(sorted));
 
     median_filter_add(&filter, 1.0f);
     median_filter_add(&filter, 2.0f);
@@ -64,7 +64,7 @@ static void test_median_filter_duplicates__handles_correctly(void) {
     float sorted[TEST_FILTER_SIZE];
     float time_ordered[TEST_FILTER_SIZE];
 
-    median_filter_init(&filter, sorted, time_ordered, TEST_FILTER_SIZE);
+    median_filter_init(&filter, sorted, time_ordered, sizeof(sorted));
 
     median_filter_add(&filter, 2.0f);
     median_filter_add(&filter, 2.0f);
@@ -81,7 +81,7 @@ static void test_average_filter_single_value__returns_value(void) {
     struct average_filter filter;
     float buffer[TEST_FILTER_SIZE];
 
-    average_filter_init(&filter, buffer, TEST_FILTER_SIZE);
+    average_filter_init(&filter, buffer, sizeof(buffer));
 
     float result = average_filter_add(&filter, 5.0f);
     TEST_ASSERT_EQUAL_FLOAT_MESSAGE(5.0f, result, "Single value should be returned as average");
@@ -91,7 +91,7 @@ static void test_average_filter_multiple_values__calculates_correctly(void) {
     struct average_filter filter;
     float buffer[TEST_FILTER_SIZE];
 
-    average_filter_init(&filter, buffer, TEST_FILTER_SIZE);
+    average_filter_init(&filter, buffer, sizeof(buffer));
 
     float result = average_filter_add(&filter, 1.0f);
     TEST_ASSERT_EQUAL_FLOAT_MESSAGE(1.0f, result, "Wrong average for filter with one value");
@@ -111,7 +111,7 @@ static void test_average_filter_overflow__moving_average(void) {
     struct average_filter filter;
     float buffer[3];
 
-    average_filter_init(&filter, buffer, 3);
+    average_filter_init(&filter, buffer, sizeof(buffer));
 
     average_filter_add(&filter, 1.0f);
     average_filter_add(&filter, 2.0f);
@@ -127,7 +127,7 @@ static void test_average_filter_negative_values__handles_correctly(void) {
     struct average_filter filter;
     float buffer[TEST_FILTER_SIZE];
 
-    average_filter_init(&filter, buffer, TEST_FILTER_SIZE);
+    average_filter_init(&filter, buffer, sizeof(buffer));
 
     average_filter_add(&filter, -2.0f);
     average_filter_add(&filter, -1.0f);
@@ -142,7 +142,7 @@ static void test_average_filter_fractional_values__precise_calculation(void) {
     struct average_filter filter;
     float buffer[3];
 
-    average_filter_init(&filter, buffer, 3);
+    average_filter_init(&filter, buffer, sizeof(buffer));
 
     /* Add precise fractional values */
     average_filter_add(&filter, 0.1f);

--- a/tests/tests_main.c
+++ b/tests/tests_main.c
@@ -12,7 +12,6 @@ int main(void) {
     UNITY_BEGIN();
     test_rocket_state();
     test_detection();
-    test_circular_buffer();
     test_filtering();
     return UNITY_END();
 }


### PR DESCRIPTION
* Removed reference to tests for old circular buffer and updated tests for the new init calls
* Updated initialization for the median and average filters to use bytes instead of elements
* Swapped in the correct calls for circbuf in filtering code