### PR TITLE
Include temperature in altitude conversion

### DIFF
--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -142,7 +142,7 @@ struct fusion_altitude calculate_altitude(struct sensor_baro *baro_data) {
     output.timestamp = baro_data->timestamp;
 
     /* Assume barometric reading is temperature adjusted */
-    output.altitude = -(GAS_CONSTANT * KELVIN) / (MOLAR_MASS * GRAVITY) * log(baro_data->pressure / SEA_PRESSURE);
+    output.altitude = -(GAS_CONSTANT * (KELVIN + baro_data->temperature)) / (MOLAR_MASS * GRAVITY) * log(baro_data->pressure / SEA_PRESSURE);
     return output;
 }
 


### PR DESCRIPTION
Added the current temperature from the barometer to the calculation. I was using the conversion constant instead of the standard temperature before (which would have been 288K).