### PR TITLE
Configures sensors at startup with their required frequencies and FSRs.

### DIFF
--- a/telemetry/Kconfig
+++ b/telemetry/Kconfig
@@ -119,4 +119,48 @@ config INSPACE_TELEMETRY_EEPROM
     ---help---
         The path identifier of the eeprom device for storing settings.
 
+comment "Sampling options"
+
+config INSPACE_TELEMETRY_ACCEL_SF
+	int "Accelerometer sampling frequency"
+	default 100
+	range 1 6600
+	---help---
+		The sampling frequency for the accelerometer in Hz
+
+config INSPACE_TELEMETRY_GYRO_SF
+	int "Gyroscope sampling frequency"
+	default 100
+	range 1 6600
+	---help---
+		The sampling frequency for the gyroscope in Hz
+
+config INSPACE_TELEMETRY_MAG_SF
+	int "Magnetometer sampling frequency"
+	default 50
+	range 1 50
+	---help---
+		The sampling frequency for the magnetometer in Hz
+
+config INSPACE_TELEMETRY_BARO_SF
+	int "Barometer sampling frequency"
+	default 50
+	range 1 100
+	---help---
+		The sampling frequency for the barometer in Hz
+
+config INSPACE_TELEMETRY_GPS_SF
+	int "GPS sampling frequency"
+	default 10
+	range 1 10
+	---help---
+		The sampling frequency for the GPS in Hz
+
+config INSPACE_TELEMETRY_ALT_SF
+	int "Altitude sampling frequency"
+	default 25
+	range 1 INSPACE_TELEMETRY_BARO_SF
+	---help---
+		The sampling frequency for fusion altitude
+
 endif # INSPACE_TELEMETRY

--- a/telemetry/Kconfig
+++ b/telemetry/Kconfig
@@ -81,6 +81,13 @@ config INSPACE_TELEMETRY_STARTBUFFER
         seconds is kept up to date. This ensures that lift-off detection latency
         does not cause data loss about the initial lift-off.
 
+config INSPACE_TELEMETRY_BUFFER_N_PACKETS
+	int "Number of buffered packets"
+	default 3
+	range 0 128
+	---help---
+		The number of packets to buffer at a time in the packet queues.
+
 config INSPACE_TELEMETRY_FLIGHT_FS
     string "Flight logging filesystem"
     default "/mnt/pwrfs"

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -353,23 +353,6 @@ void *collection_main(void *arg) {
             void *sensor_start = uorb_data_buffers[i];
             process_one(handlers[i], &context, &sensor_start, sensor_end, uorb_metas[i]->o_size);
         }
-
-        /* Decide whether to move to lift-off state. TODO: real logic */
-
-        switch (flight_state) {
-        case STATE_IDLE: {
-            // Perform lift-off detection operations
-            // If lift-off:
-            // state_set_flightstate(state, STATE_AIRBORNE);
-        } break;
-        case STATE_AIRBORNE: {
-            // Perform landing detection operations
-            // If landed
-            // state_set_flightstate(state, STATE_LANDED);
-        } break;
-        case STATE_LANDED:
-            break; /* Do nothing, just continue collecting */
-        }
     }
 
     pthread_exit(0);

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -133,7 +133,6 @@ void *logging_main(void *arg) {
 
             // Have to flush and sync on the power safe file system to commit writes. Do this sparingly to save time
             if ((packet_seq_num & 0x03) == 0) {
-                fflush(active_file);
                 fsync(fileno(active_file));
             }
 

--- a/telemetry/src/packets/buffering.c
+++ b/telemetry/src/packets/buffering.c
@@ -1,121 +1,87 @@
 #include "buffering.h"
 #include "../syslogging.h"
+#include <nuttx/queue.h>
 
-/**
- * Initialize a packet queue. Must be performed before using the queue
- * 
+/* Initialize a packet queue. Must be performed before using the queue
+ *
  * @param queue Pointer to the queue
  * @return 0 on success, non-zero error code on mutex initialization failure
  */
 static int packet_queue_init(struct packet_queue *queue) {
-    int err = pthread_mutex_init(&queue->lock, NULL);
-    if (err) {
-        return err;
-    }
+    int err;
+
+    err = pthread_mutex_init(&queue->lock, NULL);
+    if (err) return err;
+
     err = pthread_cond_init(&queue->not_empty, NULL);
     if (err) {
         pthread_mutex_destroy(&queue->lock);
         return err;
     }
-    queue->head = NULL;
-    queue->tail = NULL;
+    sq_init(&queue->q);
     return err;
 }
 
-/**
- * Remove and return the first node from the queue
- * 
+/* Remove and return the first node from the queue
+ *
  * @param queue Pointer to the queue
  * @return Pointer to the removed node, or NULL if queue is empty
  */
-static packet_node_t* packet_queue_lpop(struct packet_queue *queue) {
-    packet_node_t *node = NULL;
+static packet_node_t *packet_queue_lpop(struct packet_queue *queue) {
+    packet_node_t *node;
     pthread_mutex_lock(&queue->lock);
-    if (queue->head) {
-        node = queue->head;
-        queue->head = node->next;
-        if (queue->head) {
-            queue->head->prev = NULL;
-        } else {
-            queue->tail = NULL;
-        }
-    }
+    node = (packet_node_t *)sq_remfirst(&queue->q);
     pthread_mutex_unlock(&queue->lock);
     return node;
 }
 
-/**
- * Remove and return the first node from the queue, block if there are no nodes
- * 
+/* Remove and return the first node from the queue, block if there are no nodes
+ *
  * @param queue Pointer to the queue
  * @return Pointer to the removed node
  */
-static packet_node_t* packet_queue_wait_lpop(struct packet_queue *queue) {
-    packet_node_t *node = NULL;
+static packet_node_t *packet_queue_wait_lpop(struct packet_queue *queue) {
+    packet_node_t *node;
     pthread_mutex_lock(&queue->lock);
 
-    while (queue->head == NULL) {
+    while (sq_empty(&queue->q)) {
         indebug("Waiting for a full packet\n");
         pthread_cond_wait(&queue->not_empty, &queue->lock);
     }
 
-    node = queue->head;
-    queue->head = node->next;
-    if (queue->head) {
-        queue->head->prev = NULL;
-    } else {
-        queue->tail = NULL;
-    }
+    node = (packet_node_t *)sq_remfirst(&queue->q);
     pthread_mutex_unlock(&queue->lock);
     return node;
 }
 
-/**
- * Remove and return the last node from the queue
- * 
+/* Remove and return the last node from the queue
+ *
  * @param queue Pointer to the queue
  * @return Pointer to the removed node, or NULL if queue is empty
  */
-static packet_node_t* packet_queue_rpop(struct packet_queue *queue) {
+static packet_node_t *packet_queue_rpop(struct packet_queue *queue) {
     packet_node_t *node = NULL;
     pthread_mutex_lock(&queue->lock);
-    if (queue->tail) {
-        node = queue->tail;
-        queue->tail = node->prev;
-        if (queue->tail) {
-            queue->tail->next = NULL;
-        } else {
-            queue->head = NULL;
-        }
-        node->next = node->prev = NULL;
-    }
+    node = (packet_node_t *)sq_remlast(&queue->q);
     pthread_mutex_unlock(&queue->lock);
     return node;
 }
 
-/**
- * Add a node to the front of the queue.
- * 
+/* Add a node to the front of the queue.
+ *
  * @param queue Pointer to the queue structure
  * @param node Pointer to the node to add
  */
 static void packet_queue_push(struct packet_queue *queue, packet_node_t *node) {
     pthread_mutex_lock(&queue->lock);
-    node->next = queue->head;
-    node->prev = NULL;
-    if (queue->head) {
-        queue->head->prev = node;
-    } else {
-        queue->tail = node;
-    }
-    queue->head = node;
+    sq_addlast((sq_entry_t *)node, &queue->q);
     pthread_cond_signal(&queue->not_empty);
     pthread_mutex_unlock(&queue->lock);
 }
 
 /**
  * Initialize a packet buffer. Needs to be called before using the buffer.
- * 
+ *
  * @param buffer Pointer to the packet buffer to initialize
  * @return 0 or a negative error code on failure
  */
@@ -134,9 +100,8 @@ int packet_buffer_init(packet_buffer_t *buffer) {
     return 0;
 }
 
-/**
- * Takes an empty packet or the oldest full packet from the buffer
- * 
+/* Takes an empty packet or the oldest full packet from the buffer
+ *
  * @param buffer The buffer to get the packet from
  * @return A packet or NULL if there are no packets in the buffer
  */
@@ -150,13 +115,13 @@ packet_node_t *packet_buffer_get_empty(packet_buffer_t *buffer) {
     if (packet) {
         packet->end = packet->packet;
     }
-    indebug("Got an packet from the buffer at address %p to write into\n", packet); 
+    indebug("Got an packet from the buffer at address %p to write into\n", packet);
     return packet;
 }
 
 /**
  * Takes a full packet from the buffer, or blocks until there is one
- * 
+ *
  * @param buffer The buffer to get the packet from
  * @return A packet that has 0 or more bytes in it
  */
@@ -167,7 +132,7 @@ packet_node_t *packet_buffer_get_full(packet_buffer_t *buffer) {
 
 /**
  * Puts a empty or used packet back into the buffer
- * 
+ *
  * @param buffer The buffer to put the packet into
  * @param node The empty or used packet which can now be overwritten
  */
@@ -177,7 +142,7 @@ void packet_buffer_put_empty(packet_buffer_t *buffer, packet_node_t *node) {
 
 /**
  * Puts a full packet back into the buffer
- * 
+ *
  * @param buffer The buffer to put the packet into
  * @param node The full packet that is ready to be used by other parts of the system
  */
@@ -185,8 +150,7 @@ void packet_buffer_put_full(packet_buffer_t *buffer, packet_node_t *node) {
     indebug("Putting a full packet back into the buffer: ");
     if (node != NULL) {
         indebug("packet of length %d\n", node->end - node->packet);
-    }
-    else {
+    } else {
         indebug("node is NULL\n");
     }
     packet_queue_push(&buffer->full_queue, node);

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -19,39 +19,39 @@
 
 /* Possible sub-types of data blocks that can be sent. */
 enum block_type_e {
-  DATA_ALT_SEA = 0x0,     /* Altitude above sea level */
-  DATA_ALT_LAUNCH = 0x1,  /* Altitude above launch level */
-  DATA_TEMP = 0x2,        /* Temperature data */
-  DATA_PRESSURE = 0x3,    /* Pressure data */
-  DATA_ACCEL_REL = 0x4,   /* Relative linear acceleration data */
-  DATA_ANGULAR_VEL = 0x5, /* Angular velocity data */
-  DATA_HUMIDITY = 0x6,    /* Humidity data */
-  DATA_LAT_LONG = 0x7,    /* Latitude and longitude coordinates */
-  DATA_VOLTAGE = 0x8,     /* Voltage in millivolts with a unique ID. */
-  DATA_MAGNETIC = 0x9,    /* Magnetic field data */
-  DATA_RES_ABOVE = 0xA,   /* Types unused above this value */
+    DATA_ALT_SEA = 0x0,     /* Altitude above sea level */
+    DATA_ALT_LAUNCH = 0x1,  /* Altitude above launch level */
+    DATA_TEMP = 0x2,        /* Temperature data */
+    DATA_PRESSURE = 0x3,    /* Pressure data */
+    DATA_ACCEL_REL = 0x4,   /* Relative linear acceleration data */
+    DATA_ANGULAR_VEL = 0x5, /* Angular velocity data */
+    DATA_HUMIDITY = 0x6,    /* Humidity data */
+    DATA_LAT_LONG = 0x7,    /* Latitude and longitude coordinates */
+    DATA_VOLTAGE = 0x8,     /* Voltage in millivolts with a unique ID. */
+    DATA_MAGNETIC = 0x9,    /* Magnetic field data */
+    DATA_RES_ABOVE = 0xA,   /* Types unused above this value */
 };
 
 /* Each radio packet will have a header in this format. */
 typedef struct {
-  /* The HAM radio call sign with trailing null characters. */
-  char call_sign[9];
-  /* The measurement time that blocks in this packet are offset from in
-   * half-minutes
-   */
-  uint16_t timestamp;
-  /* The number of blocks in this packet*/
-  uint8_t blocks;
-  /* Which number this packet is in the stream of sent packets. */
-  uint8_t packet_num;
+    /* The HAM radio call sign with trailing null characters. */
+    char call_sign[9];
+    /* The measurement time that blocks in this packet are offset from in
+     * half-minutes
+     */
+    uint16_t timestamp;
+    /* The number of blocks in this packet*/
+    uint8_t blocks;
+    /* Which number this packet is in the stream of sent packets. */
+    uint8_t packet_num;
 } TIGHTLY_PACKED pkt_hdr_t;
 
 void pkt_hdr_init(pkt_hdr_t *p, uint8_t packet_number, uint32_t mission_time);
 
 /* Each block in the radio packet will have a header in this format. */
 typedef struct {
-  /* The type of this block. */
-  uint8_t type;
+    /* The type of this block. */
+    uint8_t type;
 } TIGHTLY_PACKED blk_hdr_t;
 
 void blk_hdr_init(blk_hdr_t *b, const enum block_type_e type);
@@ -64,120 +64,115 @@ uint8_t *pkt_create_blk(uint8_t *packet, uint8_t *block, enum block_type_e type,
 
 /* A data block containing information about altitude. */
 struct alt_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Altitude in units of millimetres above/below the launch height. */
-  int32_t altitude;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Altitude in units of millimetres above/below the launch height. */
+    int32_t altitude;
 } TIGHTLY_PACKED;
 
 void alt_blk_init(struct alt_blk_t *b, const int32_t altitude);
 
 /* A data block containing information about temperature. */
 struct temp_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Temperature in millidegrees Celsius. */
-  int32_t temperature;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Temperature in millidegrees Celsius. */
+    int32_t temperature;
 } TIGHTLY_PACKED;
 
 void temp_blk_init(struct temp_blk_t *b, const int32_t temperature);
 
 /* A data block containing information about humidity. */
 struct hum_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Relative humidity in ten thousandths of a percent. */
-  uint32_t humidity;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Relative humidity in ten thousandths of a percent. */
+    uint32_t humidity;
 } TIGHTLY_PACKED;
 
 void hum_blk_init(struct hum_blk_t *b, const uint32_t humidity);
 
 /* A data block containing information about pressure. */
 struct pres_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Pressure measured in Pascals. */
-  uint32_t pressure;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Pressure measured in Pascals. */
+    uint32_t pressure;
 } TIGHTLY_PACKED;
 
 void pres_blk_init(struct pres_blk_t *b, const int32_t pressure);
 
 /* A data block containing information about angular velocity. */
 struct ang_vel_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Angular velocity in the x-axis measured in tenths of degrees per second.
-   */
-  int16_t x;
-  /* Angular velocity in the y-axis measured in tenths of degrees per second.
-   */
-  int16_t y;
-  /* Angular velocity in the z-axis measured in tenths of degrees per second.
-   */
-  int16_t z;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Angular velocity in the x-axis measured in tenths of degrees per second.
+     */
+    int16_t x;
+    /* Angular velocity in the y-axis measured in tenths of degrees per second.
+     */
+    int16_t y;
+    /* Angular velocity in the z-axis measured in tenths of degrees per second.
+     */
+    int16_t z;
 } TIGHTLY_PACKED;
 
-void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis,
-                      const int16_t y_axis, const int16_t z_axis);
+void ang_vel_blk_init(struct ang_vel_blk_t *b, const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 /* A data block containing information about acceleration. */
 struct accel_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Linear acceleration in the x-axis measured in centimetres per second
-   * squared. */
-  int16_t x;
-  /* Linear acceleration in the y-axis measured in centimetres per second
-   * squared. */
-  int16_t y;
-  /* Linear acceleration in the z-axis measured in centimetres per second
-   * squared. */
-  int16_t z;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Linear acceleration in the x-axis measured in centimetres per second
+     * squared. */
+    int16_t x;
+    /* Linear acceleration in the y-axis measured in centimetres per second
+     * squared. */
+    int16_t y;
+    /* Linear acceleration in the z-axis measured in centimetres per second
+     * squared. */
+    int16_t z;
 } TIGHTLY_PACKED;
 
-void accel_blk_init(struct accel_blk_t *b, const int16_t x_axis,
-                    const int16_t y_axis, const int16_t z_axis);
+void accel_blk_init(struct accel_blk_t *b, const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 /* A data block containing information about acceleration. */
 struct mag_blk_t {
-  /* The offset from the absolute time in the header in 0.1 microtesla */
-  int16_t time_offset;
-  /* Magnetic field in the x-axis measured in 0.1 microtesla */
-  int16_t x;
-  /* Magnetic field in the y-axis measured in 0.1 microtesla */
-  int16_t y;
-  /* Magnetic field in the z-axis measured in 0.1 microtesla */
-  int16_t z;
+    /* The offset from the absolute time in the header in 0.1 microtesla */
+    int16_t time_offset;
+    /* Magnetic field in the x-axis measured in 0.1 microtesla */
+    int16_t x;
+    /* Magnetic field in the y-axis measured in 0.1 microtesla */
+    int16_t y;
+    /* Magnetic field in the z-axis measured in 0.1 microtesla */
+    int16_t z;
 } TIGHTLY_PACKED;
 
-void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis,
-                  const int16_t y_axis, const int16_t z_axis); 
+void mag_blk_init(struct mag_blk_t *b, const int16_t x_axis, const int16_t y_axis, const int16_t z_axis);
 
 /* A data block containing latitude and longitude coordinates. */
 struct coord_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Latitude in 0.1 microdegrees/LSB. */
-  int32_t latitude;
-  /* Longitude in 0.1 microdegrees/LSB. */
-  int32_t longitude;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Latitude in 0.1 microdegrees/LSB. */
+    int32_t latitude;
+    /* Longitude in 0.1 microdegrees/LSB. */
+    int32_t longitude;
 } TIGHTLY_PACKED;
 
-void coord_blk_init(struct coord_blk_t *b, const int32_t lat,
-                    const int32_t lon);
+void coord_blk_init(struct coord_blk_t *b, const int32_t lat, const int32_t lon);
 
 /* A data block containing voltage measurements and an ID for the sensor with
  * the associated voltage. */
 struct volt_blk_t {
-  /* The offset from the absolute time in the header in milliseconds */
-  int16_t time_offset;
-  /* Unique sensor ID. */
-  uint16_t id;
-  /* Voltage in millivolts. */
-  int16_t voltage;
+    /* The offset from the absolute time in the header in milliseconds */
+    int16_t time_offset;
+    /* Unique sensor ID. */
+    uint16_t id;
+    /* Voltage in millivolts. */
+    int16_t voltage;
 } TIGHTLY_PACKED;
 
-void volt_blk_init(struct volt_blk_t *b, const uint16_t id,
-                   const int16_t voltage);
+void volt_blk_init(struct volt_blk_t *b, const uint16_t id, const int16_t voltage);
 
 #endif // _INSPACE_TELEMETRY_PACKET_H_

--- a/telemetry/src/sensors/sensors.c
+++ b/telemetry/src/sensors/sensors.c
@@ -1,35 +1,7 @@
 #include <poll.h>
 
-#include "sensors.h"
 #include "../syslogging.h"
-
-/* Set up a pollfd structure for a uORB sensor
- *
- * @param sensor A pollfd struct that will be initialized with a uORB fd and for POLLIN events
- * @param meta The metadata for the topic the sensor will be subscribed to
- * @return 0 on success or a negative error code
- */
-int setup_sensor(struct pollfd *sensor, orb_id_t meta) {
-  if (meta == NULL) {
-      inerr("Could not set up sensor, missing metadata.\n");
-      return -1;
-  }
-  sensor->fd = orb_subscribe(meta);
-  sensor->events = POLLIN;
-  if (sensor->fd < 0) {
-      inerr("Sensor %s was not opened successfully", meta->o_name);
-      sensor->events = POLLIN;
-      return sensor->fd;
-  }
-#if defined(CONFIG_INSPACE_SYSLOG_OUTPUT)
-  else {
-    struct orb_state state;
-    orb_get_state(sensor->fd, &state);
-    indebug("Setup successful for sensor %s\n", meta->o_name);
-  }
-#endif
-  return 0;
-}
+#include "sensors.h"
 
 /* Gets data from the sensor if the POLLIN event has occured
  *
@@ -58,7 +30,7 @@ ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
         }
         return len;
     }
-  return 0;
+    return 0;
 }
 
 /**
@@ -67,33 +39,10 @@ ssize_t get_sensor_data(struct pollfd *sensor, void *data, size_t size) {
  * @param sensor A pollfd struct with a valid or invalid file descriptor
  * @param data An array of uORB data structs of the type this sensor uses
  * @param size The size of the data parameter in bytes
- * @return The 
+ * @return The
  */
-void *get_sensor_data_end(struct pollfd *sensor, void* data, size_t size) {
-  return data + get_sensor_data(sensor, data, size);
-}
-
-/**
- * Clears the uorb_inputs struct to make no sensors get polled on accidentally. After this,
- * should be fine to only set up a the desired sensors and poll everything
- *
- * @param sensors The uorb_inputs struct to clear
- */
-void clear_uorb_inputs(struct uorb_inputs *sensors) {
-  struct pollfd *sensor_array = (struct pollfd *)sensors;
-  for (int i = 0; i < NUM_SENSORS; i++) {
-    sensor_array[i].fd = -1;
-    sensor_array[i].events = 0;
-  }
-}
-
-/**
- * Polls on all sensors in the uorb_inputs struct
- *
- * @param sensors The uorb_inputs struct to poll on
- */
-void poll_sensors(struct uorb_inputs *sensors) {
-    poll((struct pollfd *)sensors, NUM_SENSORS, -1);
+void *get_sensor_data_end(struct pollfd *sensor, void *data, size_t size) {
+    return data + get_sensor_data(sensor, data, size);
 }
 
 /**
@@ -105,27 +54,30 @@ void poll_sensors(struct uorb_inputs *sensors) {
  * @param len The number of bytes of data in the buffer
  * @param elem_size The size of each element in the data buffer
  */
-void foreach_measurement(uorb_data_callback_t handler, void* handler_context, void *data, size_t len, size_t elem_size) {
-  for (int i = 0; i < (len / elem_size); i++) {
-    handler(handler_context, data + (i * elem_size));
-  }
+void foreach_measurement(uorb_data_callback_t handler, void *handler_context, void *data, size_t len,
+                         size_t elem_size) {
+    for (int i = 0; i < (len / elem_size); i++) {
+        handler(handler_context, data + (i * elem_size));
+    }
 }
 
 /**
  * Process one piece of data
  *
  * @param handler The handler to call on a single element in the data buffer
- * @param handler_context 
- * @param data_start A pointer to the next place in the data buffer to process, incremented by elem_size if the handler is called
+ * @param handler_context
+ * @param data_start A pointer to the next place in the data buffer to process, incremented by elem_size if the handler
+ * is called
  * @param data_end The last byte in the data buffer where there is data
  * @param elem_size The size of elements in the buffer
  * @return 1 if a piece of data was processed, 0 otherwise
  */
-int process_one(uorb_data_callback_t handler, void* handler_context, void **data_start, void *data_end, size_t elem_size) {
-  if ((*data_start == data_end) || ((elem_size + *data_start) > data_end)) {
-    return 0;
-  }
-  handler(handler_context, (*data_start));
-  (*data_start) += elem_size;
-  return 1;
+int process_one(uorb_data_callback_t handler, void *handler_context, void **data_start, void *data_end,
+                size_t elem_size) {
+    if ((*data_start == data_end) || ((elem_size + *data_start) > data_end)) {
+        return 0;
+    }
+    handler(handler_context, (*data_start));
+    (*data_start) += elem_size;
+    return 1;
 }

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -12,22 +12,22 @@
 #include "syslogging.h"
 #include "transmission/transmit.h"
 
+/* Buffers for sharing sensor data between threads */
+
+static packet_buffer_t transmit_buffer;
+static packet_buffer_t logging_buffer;
+
+static pthread_t transmit_thread;
+static pthread_t log_thread;
+static pthread_t collect_thread;
+static pthread_t fusion_thread;
+
+static rocket_state_t state; /* The shared rocket state. */
+
 int main(int argc, char **argv) {
-
-    int err = 0;
-    rocket_state_t state; /* The shared rocket state. */
-
-    /* Buffers for sharing sensor data between threads */
-
-    packet_buffer_t transmit_buffer;
-    packet_buffer_t logging_buffer;
+    int err;
 
     /* Thread handles. */
-
-    pthread_t transmit_thread;
-    pthread_t log_thread;
-    pthread_t collect_thread;
-    pthread_t fusion_thread;
 
     ininfo("You are running the Carleton University InSpace telemetry system.");
 


### PR DESCRIPTION
Changes how sensors are polled to make handling of data-flow easier. Adds a few more info logs to see the state of boot-up as well, and also skips over invalid sensor FDs/metas.

Closes #45 and #18