### PR TITLE
Roughly implement the eject LED

### DIFF
--- a/telemetry/Kconfig
+++ b/telemetry/Kconfig
@@ -132,6 +132,12 @@ config INSPACE_TELEMETRY_ADC
     ---help---
         The path identifier of the ADC device that measures battery voltage.
 
+config INSPACE_TELEMETRY_EJECTLED
+    string "Eject LED"
+    default "/dev/gpio0"
+    ---help---
+        The path identifier of the GPIO which control the EJECT LED.
+
 comment "Sampling options"
 
 config INSPACE_TELEMETRY_ACCEL_SF

--- a/telemetry/src/collection/collection.c
+++ b/telemetry/src/collection/collection.c
@@ -8,10 +8,10 @@
 #include <poll.h>
 #include <pthread.h>
 #include <sys/ioctl.h>
-
-#include <nuttx/analog/adc.h>>
-#include <nuttx/sensors/sensor.h>
 #include <unistd.h>
+
+#include <nuttx/analog/adc.h>
+#include <nuttx/sensors/sensor.h>
 
 #include "../fusion/fusion.h"
 #include "../syslogging.h"


### PR DESCRIPTION
Closes #29.

Not too sure if this should be partially controlled from where the flight state is set. At the very least, an optimization could be made to only change the LED status on a state change instead of every loop within that state.