### PR TITLE
Fusion thread now detects flight states properly

### DIFF
--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -122,9 +122,13 @@ void *logging_main(void *arg) {
 
         case STATE_AIRBORNE: {
 
-            /* Not safe to eject from now until files are copied */
+            /* Not safe to eject from now onward until files are copied. if-statement is to guard against idle state
+             * fall-through.
+             */
 
-            ejectled_set(false);
+            if (flight_state == STATE_AIRBORNE) {
+                ejectled_set(false);
+            }
 
             // Get the next packet, or wait if there isn't one yet
             packet_node_t *next_packet = packet_buffer_get_full(buffer);
@@ -472,7 +476,7 @@ static int ejectled_set(bool on) {
         inerr("Could not turn on eject LED: %d\n", errno);
         return errno;
     }
-    ininfo("Eject LED %s.", on ? "on" : "off");
+    indebug("Eject LED %s.", on ? "on" : "off");
 
     err = close(fd);
     if (err < 0) {

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -10,7 +10,6 @@
 #endif
 
 #include "../packets/packets.h"
-#include "../rocket-state/rocket-state.h"
 #include "../syslogging.h"
 #include "transmit.h"
 
@@ -51,7 +50,6 @@ void *transmit_main(void *arg) {
     int err;
     int radio; /* Radio device file descriptor */
     struct transmit_args *unpacked_args = (struct transmit_args *)arg;
-    rocket_state_t *state = unpacked_args->state;
     packet_buffer_t *buffer = unpacked_args->buffer;
     uint32_t seq_num = 0;
 


### PR DESCRIPTION
Because POLLIN events are set up. Eject LED is active after files are copied until AIRBORNE state is achieved again.