### PR TITLE
Reset window when state changes to airborne

### DIFF
--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -131,7 +131,7 @@ void *fusion_main(void *arg) {
 
             /* NOTE: This is how the detector gets set into the IDLE state by the logging thread */
             detector_set_state(&detector, flight_state, flight_substate);
-            indebug("Acceleration - %.2f, Altitude - %.2f\n", detector_get_accel(&detector), detector_get_alt(&detector));
+            ininfo("Acceleration - %.2f, Altitude - %.2f\n", detector_get_accel(&detector), detector_get_alt(&detector));
         }
 
         /* Run detection. Potentially run periodically instead of every update */

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -411,7 +411,11 @@ static int ejectled_set(bool on) {
     int fd;
     int err;
 
-    fd = open(CONFIG_INSPACE_TELEMETRY_EJECTLED, O_RDONLY);
+    int oflags = O_RDONLY;
+#ifdef CONFIG_ARCH_SIM
+    oflags |= O_CREAT;
+#endif
+    fd = open(CONFIG_INSPACE_TELEMETRY_EJECTLED, oflags);
     if (fd < 0) {
         inerr("Could not open %s: %d\n", CONFIG_INSPACE_TELEMETRY_EJECTLED, errno);
         return errno;

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -53,6 +53,10 @@ int main(int argc, char **argv) {
         if (err) {
             inerr("Could not set flight substate, continuing anyways: %d\n", err);
         }
+    } else {
+        enum flight_state_e flight_state;
+        state_get_flightstate(&state, &flight_state);
+        ininfo("Loaded state: %d from EEPROM\n", flight_state);
     }
 
     /* Grab configuration parameters from EEPROM */


### PR DESCRIPTION
Small detector changes
* If we are in the idle mode, and we detect airborne based off acceleration spiking, this change requires a following ten seconds of the altitude window criteria being satisfied, preventing us from switching back to the landed state if the acceleration then drops back to a normal value.
  * I don't think this fixes anything important or necessary, but might make sure we don't switch back to landed at an inopportune time

Logging some more information that might be useful
* Changed the periodic detector accel & alt update to be info level instead of debug, since this info is so useful to have
* Added a statement to note which state was loaded on startup