### PR TITLE
Fix for syslogging error when building with sim

### DIFF
--- a/telemetry/src/syslogging.c
+++ b/telemetry/src/syslogging.c
@@ -10,15 +10,17 @@ FILE *__syslogging_file;
 atomic_int syslog_count;
 
 /*
- * Sets up the syslogging to a file
- * @return Zero on success, or errno on failure
+ * Sets up the syslogging to a file if syslog output is enabled.
+ * @return Zero on success or skip, or errno on failure
  */
 int setup_syslogging(void) {
+#ifdef CONFIG_INSPACE_SYSLOG_PATH
     atomic_set(&syslog_count, 0);
     __syslogging_file = fopen(CONFIG_INSPACE_SYSLOG_PATH, "a");
     if (__syslogging_file == NULL) {
         return errno;
     }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Resolves #86 .
The issue was with an undefined macro that's caused when "Enable Syslog Output" isn't enabled in `make menuconfig`. A simple fix here just checks if the macro is defined or not, and if not, it skips syslog setup.

An alternative or additional solution to this PR would be to make `INSPACE_TELEM` depend on `CONFIG_INSPACE_SYSLOG_OUTPUT` which would ensure the macro is defined however, if we want to be able to disable the syslog output, then this PR alone should be good.

This PR has been tested on Josh, and I have heard the startup sound.