### PR TITLE
Feat/uorb logging

### DIFF
--- a/telemetry/src/collection/status-update.c
+++ b/telemetry/src/collection/status-update.c
@@ -23,7 +23,6 @@ ORB_DEFINE(status_message, struct status_message, 0);
  */
 int publish_status(enum status_code_e status_code) {
     struct status_message status = {.timestamp = orb_absolute_time(), .status_code = status_code};
-    ininfo("Publishing a status message with code %d\n", status_code);
     return orb_publish_auto(ORB_ID(status_message), NULL, &status, NULL);
 }
 

--- a/telemetry/src/collection/status-update.h
+++ b/telemetry/src/collection/status-update.h
@@ -34,7 +34,7 @@ enum error_code_e {
 /* Process IDs for error messages */
 enum process_id_e {
     PROC_ID_GENERAL = 0x00,    /* General error process ID */
-    PROC_ID_COLLECTION = 0x01, /* Collection thread */
+    PROC_ID_DOWNSAMPLE = 0x01, /* Collection thread */
     PROC_ID_FUSION = 0x02,     /* Fusion thread */
     PROC_ID_LOGGING = 0x03,    /* Logging thread */
     PROC_ID_TRANSMIT = 0x04,   /* Transmit thread */

--- a/telemetry/src/fusion/fusion.c
+++ b/telemetry/src/fusion/fusion.c
@@ -131,7 +131,6 @@ void *fusion_main(void *arg) {
 
             /* NOTE: This is how the detector gets set into the IDLE state by the logging thread */
             detector_set_state(&detector, flight_state, flight_substate);
-            ininfo("Acceleration - %.2f, Altitude - %.2f\n", detector_get_accel(&detector), detector_get_alt(&detector));
         }
 
         /* Run detection. Potentially run periodically instead of every update */

--- a/telemetry/src/logging/logging.c
+++ b/telemetry/src/logging/logging.c
@@ -70,11 +70,6 @@ union uorb_data {
     struct error_message error;
 };
 
-typedef struct {
-    enum uorb_sensors type;
-    union uorb_data data;
-} uorb_block_t TIGHTLY_PACKED;
-
 /* uORB polling file descriptors */
 
 static struct pollfd uorb_fds[] = {

--- a/telemetry/src/packets/packets.c
+++ b/telemetry/src/packets/packets.c
@@ -371,18 +371,6 @@ int orb_gnss_pkt(struct sensor_gnss *gnss, struct coord_blk_t *blk, uint16_t bas
     return 0;
 }
 
-int orb_battery_pkt(struct sensor_battery *battery, struct volt_blk_t *blk, uint16_t base_time) {
-    int16_t time_offset;
-    if (pkt_blk_calc_time(us_to_ms(battery->timestamp), base_time, &time_offset)) {
-        inerr("Failed to calculate time offset for Battery block\n");
-        return -1;
-    }
-    blk->time_offset = time_offset;
-    blk->voltage = (int16_t)battery->voltage;
-    blk->id = 0;
-    return 0;
-}
-
 int orb_error_pkt(struct error_message *error, struct error_blk_t *blk, uint16_t base_time) {
     int16_t time_offset;
     if (pkt_blk_calc_time(us_to_ms(error->timestamp), base_time, &time_offset)) {

--- a/telemetry/src/packets/packets.h
+++ b/telemetry/src/packets/packets.h
@@ -211,7 +211,6 @@ int orb_baro_pkt(struct sensor_baro *baro, struct pres_blk_t *blk, uint16_t base
 int orb_baro_temp_pkt(struct sensor_baro *baro, struct temp_blk_t *blk, uint16_t base_time);
 int orb_alt_pkt(struct fusion_altitude *alt, struct alt_blk_t *blk, uint16_t base_time);
 int orb_gnss_pkt(struct sensor_gnss *gnss, struct coord_blk_t *blk, uint16_t base_time);
-int orb_battery_pkt(struct sensor_battery *battery, struct volt_blk_t *blk, uint16_t base_time);
 int orb_error_pkt(struct error_message *error, struct error_blk_t *blk, uint16_t base_time);
 int orb_status_pkt(struct status_message *status, struct status_blk_t *blk, uint16_t base_time);
 

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -114,11 +114,11 @@ int main(int argc, char **argv) {
         goto exit_error;
     }
 
-    // err = pthread_create(&log_thread, NULL, logging_main, NULL);
-    // if (err) {
-    //     inerr("Problem starting logging thread: %d\n", err);
-    //     goto exit_error;
-    // }
+    err = pthread_create(&log_thread, NULL, logging_main, NULL);
+    if (err) {
+        inerr("Problem starting logging thread: %d\n", err);
+        goto exit_error;
+    }
 
 #ifdef CONFIG_INSPACE_TELEMETRY_USBSH
     struct shell_args shell_args;
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
     err = pthread_join(fusion_thread, NULL);
     err = pthread_join(downsample_thread, NULL);
     err = pthread_join(transmit_thread, NULL);
-    // err = pthread_join(log_thread, NULL);
+    err = pthread_join(log_thread, NULL);
 #ifdef CONFIG_INSPACE_TELEMETRY_USBSH
     err = pthread_join(shell_thread, NULL);
 #endif


### PR DESCRIPTION
Changed sd card logging from custom packet spec to uorb structs

Logging thread subscribes to uorb topics, logs header and body separately. The header only consists of the type of struct.

Memcopying the header and body into a single var and logging it proved to slow down the system at 1000hz imu logging, thus separate logging.

Additional precautions were taken in the situation where the logging of the header succeeds but of the body fails.

A write retry mechanism is implemented, for now without delay between attempts.

Ping pong mechanism for conditional logging was removed as discussed.

Missing:
- copy from pwrfs to usrfs on landing
- logging of additional GNSS structs (rev a doesn't have a working gnss chip, can't test)