### PR TITLE
Fixing transmission thread priority inversion

### DIFF
--- a/telemetry/src/collection/downsample.c
+++ b/telemetry/src/collection/downsample.c
@@ -10,6 +10,7 @@
 #include <poll.h>
 #include <pthread.h>
 #include <sys/ioctl.h>
+#include <time.h>
 #include <unistd.h>
 
 /* Cast an error to a void pointer */
@@ -79,20 +80,20 @@ static uint8_t data_buf[sizeof(union uorb_data) * 10];
 #define NUM_SENSORS (sizeof(uorb_fds) / sizeof(uorb_fds[0]))
 
 typedef struct {
-    float mean[3];                /* the downsampled output, 3 fields to account for sensors with 3 axes */
-    uint16_t curr_sample_count;   /* the number of samples taken to calculate the mean */
-    uint16_t tot_sample_count;    /* the total number of samples taken until the queue is cleared */
-    uint16_t target_sample_count; /* number of measurements to account for in a sample */
+    float out[3];             /* downsampled output, 3 fields for sensors with 3 axes */
+    uint16_t window_n;        /* number of samples accumulated in the current downsampling window */
+    uint16_t target_window_n; /* target number of input samples per downsampled output */
+    uint16_t total_n;         /* total samples since last buffer swap, used for dynamic rate adjustment */
+    uint16_t dropped_n;       /* output blocks dropped since last buffer swap */
+    uint16_t output_n;        /* output blocks written since last swap */
 } sensor_downsampling_t;
 
 static sensor_downsampling_t sensor_downsamples[] = {
-    [SENSOR_ACCEL] = {.target_sample_count =
-                          CONFIG_INSPACE_TELEMETRY_ACCEL_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
-    [SENSOR_GYRO] = {.target_sample_count = CONFIG_INSPACE_TELEMETRY_GYRO_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
-    [SENSOR_MAG] = {.target_sample_count = CONFIG_INSPACE_TELEMETRY_MAG_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
-    [SENSOR_GNSS] = {.target_sample_count = CONFIG_INSPACE_TELEMETRY_GPS_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
-    [SENSOR_ALT] = {.target_sample_count = CONFIG_INSPACE_TELEMETRY_ALT_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
-    [SENSOR_BARO] = {.target_sample_count = CONFIG_INSPACE_TELEMETRY_BARO_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
+    [SENSOR_ACCEL] = {.target_window_n = CONFIG_INSPACE_TELEMETRY_ACCEL_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
+    [SENSOR_GYRO] = {.target_window_n = CONFIG_INSPACE_TELEMETRY_GYRO_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
+    [SENSOR_MAG] = {.target_window_n = CONFIG_INSPACE_TELEMETRY_MAG_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
+    [SENSOR_GNSS] = {.target_window_n = CONFIG_INSPACE_TELEMETRY_GPS_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
+    [SENSOR_ALT] = {.target_window_n = CONFIG_INSPACE_TELEMETRY_ALT_SF / CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ},
 };
 
 /*
@@ -175,9 +176,32 @@ void *downsample_main(void *arg) {
     ininfo("Sensor frequencies set.\n");
 #endif
 
+    /* keepint track of sampling rates */
+    uint32_t rate_counts[NUM_SENSORS] = {0};
+    struct timespec rate_report_start;
+    clock_gettime(CLOCK_MONOTONIC, &rate_report_start);
+
     /* Measure data forever */
     for (;;) {
         poll(uorb_fds, NUM_SENSORS, -1);
+
+        if (sem_trywait(&radio_telem->swapped) == 0) {
+            for (int k = 0; k < NUM_SENSORS; k++) {
+                if (k == SENSOR_BARO) continue;
+                int new_target_window_n = sensor_downsamples[k].total_n / (CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ - 1);
+                if (sensor_downsamples[k].dropped_n > 0) {
+                    new_target_window_n = new_target_window_n *
+                                          (CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ + sensor_downsamples[k].dropped_n) /
+                                          CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ;
+                }
+                if (new_target_window_n > 0 && new_target_window_n != sensor_downsamples[k].target_window_n) {
+                    sensor_downsamples[k].target_window_n = new_target_window_n;
+                }
+                sensor_downsamples[k].total_n = 0;
+                sensor_downsamples[k].dropped_n = 0;
+                sensor_downsamples[k].output_n = 0;
+            }
+        }
 
         for (int i = 0; i < NUM_SENSORS; i++) {
 
@@ -197,45 +221,16 @@ void *downsample_main(void *arg) {
                 continue;
             }
 
-            pthread_mutex_lock(&radio_telem->empty_mux);
-
-            /* check if the telemetry thread has swapped the buffer */
-            if (radio_telem->empty->accel_n == -1 || radio_telem->empty->gyro_n == -1 ||
-                radio_telem->empty->mag_n == -1 || radio_telem->empty->gnss_n == -1 ||
-                radio_telem->empty->alt_n == -1) {
-
-                for (int k = 0; k < sizeof(sensor_downsamples) / sizeof(sensor_downsamples[0]); k++) {
-
-                    /* conservative formula for the new target sample count, +1 is added to avoid jitter and keep the
-                     * output at the target frequency */
-                    int new_target_sample_count =
-                        sensor_downsamples[k].tot_sample_count / (CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ + 1);
-                    if (new_target_sample_count > 0 &&
-                        new_target_sample_count != sensor_downsamples[k].target_sample_count) {
-                        sensor_downsamples[k].target_sample_count = new_target_sample_count;
-                    }
-
-                    sensor_downsamples[k].tot_sample_count = 0;
-                    sensor_downsamples[k].curr_sample_count = 0;
-                    sensor_downsamples[k].mean[0] = 0;
-                    sensor_downsamples[k].mean[1] = 0;
-                    sensor_downsamples[k].mean[2] = 0;
-                }
-
-                radio_telem->empty->accel_n = 0;
-                radio_telem->empty->gyro_n = 0;
-                radio_telem->empty->mag_n = 0;
-                radio_telem->empty->gnss_n = 0;
-                radio_telem->empty->alt_n = 0;
-            }
-
             for (int j = 0; j < (err / uorb_metas[i]->o_size); j++) {
-                sensor_downsamples[i].tot_sample_count++;
-                sensor_downsamples[i].curr_sample_count++;
+                sensor_downsamples[i].total_n++;
+                sensor_downsamples[i].window_n++;
+                rate_counts[i]++;
 
                 switch (i) {
                 case SENSOR_ACCEL: {
-                    if (radio_telem->empty->accel_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                    if (radio_telem->empty_buff->accel_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        sensor_downsamples[SENSOR_ACCEL].dropped_n++;
+                        sensor_downsamples[SENSOR_ACCEL].window_n = 0;
                         break;
                     }
 
@@ -245,37 +240,39 @@ void *downsample_main(void *arg) {
                     using the Welford formula to calculate the mean, one pass for each axis
                     mean = mean_(n-1) + (x - mean_(n-1)) / n
                     */
-                    sensor_downsamples[SENSOR_ACCEL].mean[0] +=
-                        (accel_input.x - sensor_downsamples[SENSOR_ACCEL].mean[0]) /
-                        sensor_downsamples[SENSOR_ACCEL].curr_sample_count;
-                    sensor_downsamples[SENSOR_ACCEL].mean[1] +=
-                        (accel_input.y - sensor_downsamples[SENSOR_ACCEL].mean[1]) /
-                        sensor_downsamples[SENSOR_ACCEL].curr_sample_count;
-                    sensor_downsamples[SENSOR_ACCEL].mean[2] +=
-                        (accel_input.z - sensor_downsamples[SENSOR_ACCEL].mean[2]) /
-                        sensor_downsamples[SENSOR_ACCEL].curr_sample_count;
+                    sensor_downsamples[SENSOR_ACCEL].out[0] +=
+                        (accel_input.x - sensor_downsamples[SENSOR_ACCEL].out[0]) /
+                        sensor_downsamples[SENSOR_ACCEL].window_n;
+                    sensor_downsamples[SENSOR_ACCEL].out[1] +=
+                        (accel_input.y - sensor_downsamples[SENSOR_ACCEL].out[1]) /
+                        sensor_downsamples[SENSOR_ACCEL].window_n;
+                    sensor_downsamples[SENSOR_ACCEL].out[2] +=
+                        (accel_input.z - sensor_downsamples[SENSOR_ACCEL].out[2]) /
+                        sensor_downsamples[SENSOR_ACCEL].window_n;
 
-                    if (sensor_downsamples[SENSOR_ACCEL].curr_sample_count ==
-                        sensor_downsamples[SENSOR_ACCEL].target_sample_count) {
+                    if (sensor_downsamples[SENSOR_ACCEL].window_n >= sensor_downsamples[SENSOR_ACCEL].target_window_n) {
 
                         struct sensor_accel sensor_accel = {
                             .timestamp = accel_input.timestamp,
-                            .x = sensor_downsamples[SENSOR_ACCEL].mean[0],
-                            .y = sensor_downsamples[SENSOR_ACCEL].mean[1],
-                            .z = sensor_downsamples[SENSOR_ACCEL].mean[2],
+                            .x = sensor_downsamples[SENSOR_ACCEL].out[0],
+                            .y = sensor_downsamples[SENSOR_ACCEL].out[1],
+                            .z = sensor_downsamples[SENSOR_ACCEL].out[2],
                         };
 
-                        radio_telem->empty->accel[radio_telem->empty->accel_n++] = sensor_accel;
-                        sensor_downsamples[SENSOR_ACCEL].mean[0] = 0;
-                        sensor_downsamples[SENSOR_ACCEL].mean[1] = 0;
-                        sensor_downsamples[SENSOR_ACCEL].mean[2] = 0;
-                        sensor_downsamples[SENSOR_ACCEL].curr_sample_count = 0;
+                        radio_telem->empty_buff->accel[radio_telem->empty_buff->accel_n++] = sensor_accel;
+                        sensor_downsamples[SENSOR_ACCEL].output_n++;
+                        sensor_downsamples[SENSOR_ACCEL].out[0] = 0;
+                        sensor_downsamples[SENSOR_ACCEL].out[1] = 0;
+                        sensor_downsamples[SENSOR_ACCEL].out[2] = 0;
+                        sensor_downsamples[SENSOR_ACCEL].window_n = 0;
                     }
 
                     break;
                 }
                 case SENSOR_GYRO: {
-                    if (radio_telem->empty->gyro_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                    if (radio_telem->empty_buff->gyro_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        sensor_downsamples[SENSOR_GYRO].dropped_n++;
+                        sensor_downsamples[SENSOR_GYRO].window_n = 0;
                         break;
                     }
 
@@ -285,36 +282,35 @@ void *downsample_main(void *arg) {
                     using the Welford formula to calculate the mean, one pass for each axis
                     mean = mean_(n-1) + (x - mean_(n-1)) / n
                     */
-                    sensor_downsamples[SENSOR_GYRO].mean[0] +=
-                        (gyro_input.x - sensor_downsamples[SENSOR_GYRO].mean[0]) /
-                        sensor_downsamples[SENSOR_GYRO].curr_sample_count;
-                    sensor_downsamples[SENSOR_GYRO].mean[1] +=
-                        (gyro_input.y - sensor_downsamples[SENSOR_GYRO].mean[1]) /
-                        sensor_downsamples[SENSOR_GYRO].curr_sample_count;
-                    sensor_downsamples[SENSOR_GYRO].mean[2] +=
-                        (gyro_input.z - sensor_downsamples[SENSOR_GYRO].mean[2]) /
-                        sensor_downsamples[SENSOR_GYRO].curr_sample_count;
+                    sensor_downsamples[SENSOR_GYRO].out[0] += (gyro_input.x - sensor_downsamples[SENSOR_GYRO].out[0]) /
+                                                              sensor_downsamples[SENSOR_GYRO].window_n;
+                    sensor_downsamples[SENSOR_GYRO].out[1] += (gyro_input.y - sensor_downsamples[SENSOR_GYRO].out[1]) /
+                                                              sensor_downsamples[SENSOR_GYRO].window_n;
+                    sensor_downsamples[SENSOR_GYRO].out[2] += (gyro_input.z - sensor_downsamples[SENSOR_GYRO].out[2]) /
+                                                              sensor_downsamples[SENSOR_GYRO].window_n;
 
-                    if (sensor_downsamples[SENSOR_GYRO].curr_sample_count ==
-                        sensor_downsamples[SENSOR_GYRO].target_sample_count) {
+                    if (sensor_downsamples[SENSOR_GYRO].window_n >= sensor_downsamples[SENSOR_GYRO].target_window_n) {
                         struct sensor_gyro sensor_gyro = {
                             .timestamp = gyro_input.timestamp,
-                            .x = sensor_downsamples[SENSOR_GYRO].mean[0],
-                            .y = sensor_downsamples[SENSOR_GYRO].mean[1],
-                            .z = sensor_downsamples[SENSOR_GYRO].mean[2],
+                            .x = sensor_downsamples[SENSOR_GYRO].out[0],
+                            .y = sensor_downsamples[SENSOR_GYRO].out[1],
+                            .z = sensor_downsamples[SENSOR_GYRO].out[2],
                         };
 
-                        radio_telem->empty->gyro[radio_telem->empty->gyro_n++] = sensor_gyro;
-                        sensor_downsamples[SENSOR_GYRO].mean[0] = 0;
-                        sensor_downsamples[SENSOR_GYRO].mean[1] = 0;
-                        sensor_downsamples[SENSOR_GYRO].mean[2] = 0;
-                        sensor_downsamples[SENSOR_GYRO].curr_sample_count = 0;
+                        radio_telem->empty_buff->gyro[radio_telem->empty_buff->gyro_n++] = sensor_gyro;
+                        sensor_downsamples[SENSOR_GYRO].output_n++;
+                        sensor_downsamples[SENSOR_GYRO].out[0] = 0;
+                        sensor_downsamples[SENSOR_GYRO].out[1] = 0;
+                        sensor_downsamples[SENSOR_GYRO].out[2] = 0;
+                        sensor_downsamples[SENSOR_GYRO].window_n = 0;
                     }
 
                     break;
                 }
                 case SENSOR_MAG: {
-                    if (radio_telem->empty->mag_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                    if (radio_telem->empty_buff->mag_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        sensor_downsamples[SENSOR_MAG].dropped_n++;
+                        sensor_downsamples[SENSOR_MAG].window_n = 0;
                         break;
                     }
 
@@ -324,39 +320,42 @@ void *downsample_main(void *arg) {
                     using the Welford formula to calculate the mean, one pass for each axis
                     mean = mean_(n-1) + (x - mean_(n-1)) / n
                     */
-                    sensor_downsamples[SENSOR_MAG].mean[0] += (mag_input.x - sensor_downsamples[SENSOR_MAG].mean[0]) /
-                                                              sensor_downsamples[SENSOR_MAG].curr_sample_count;
-                    sensor_downsamples[SENSOR_MAG].mean[1] += (mag_input.y - sensor_downsamples[SENSOR_MAG].mean[1]) /
-                                                              sensor_downsamples[SENSOR_MAG].curr_sample_count;
-                    sensor_downsamples[SENSOR_MAG].mean[2] += (mag_input.z - sensor_downsamples[SENSOR_MAG].mean[2]) /
-                                                              sensor_downsamples[SENSOR_MAG].curr_sample_count;
+                    sensor_downsamples[SENSOR_MAG].out[0] +=
+                        (mag_input.x - sensor_downsamples[SENSOR_MAG].out[0]) / sensor_downsamples[SENSOR_MAG].window_n;
+                    sensor_downsamples[SENSOR_MAG].out[1] +=
+                        (mag_input.y - sensor_downsamples[SENSOR_MAG].out[1]) / sensor_downsamples[SENSOR_MAG].window_n;
+                    sensor_downsamples[SENSOR_MAG].out[2] +=
+                        (mag_input.z - sensor_downsamples[SENSOR_MAG].out[2]) / sensor_downsamples[SENSOR_MAG].window_n;
 
-                    if (sensor_downsamples[SENSOR_MAG].curr_sample_count ==
-                        sensor_downsamples[SENSOR_MAG].target_sample_count) {
+                    if (sensor_downsamples[SENSOR_MAG].window_n >= sensor_downsamples[SENSOR_MAG].target_window_n) {
                         struct sensor_mag sensor_mag = {
                             .timestamp = mag_input.timestamp,
-                            .x = sensor_downsamples[SENSOR_MAG].mean[0],
-                            .y = sensor_downsamples[SENSOR_MAG].mean[1],
-                            .z = sensor_downsamples[SENSOR_MAG].mean[2],
+                            .x = sensor_downsamples[SENSOR_MAG].out[0],
+                            .y = sensor_downsamples[SENSOR_MAG].out[1],
+                            .z = sensor_downsamples[SENSOR_MAG].out[2],
                         };
 
-                        if (radio_telem->empty->mag_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        if (radio_telem->empty_buff->mag_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
                             inerr("Magnetometer buffer full, dropping data\n");
+                            sensor_downsamples[SENSOR_MAG].dropped_n++;
+                            sensor_downsamples[SENSOR_MAG].window_n = 0;
                             break;
                         }
 
-                        radio_telem->empty->mag[radio_telem->empty->mag_n++] = sensor_mag;
-
-                        sensor_downsamples[SENSOR_MAG].mean[0] = 0;
-                        sensor_downsamples[SENSOR_MAG].mean[1] = 0;
-                        sensor_downsamples[SENSOR_MAG].mean[2] = 0;
-                        sensor_downsamples[SENSOR_MAG].curr_sample_count = 0;
+                        radio_telem->empty_buff->mag[radio_telem->empty_buff->mag_n++] = sensor_mag;
+                        sensor_downsamples[SENSOR_MAG].output_n++;
+                        sensor_downsamples[SENSOR_MAG].out[0] = 0;
+                        sensor_downsamples[SENSOR_MAG].out[1] = 0;
+                        sensor_downsamples[SENSOR_MAG].out[2] = 0;
+                        sensor_downsamples[SENSOR_MAG].window_n = 0;
                     }
 
                     break;
                 }
                 case SENSOR_GNSS: {
-                    if (radio_telem->empty->gnss_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                    if (radio_telem->empty_buff->gnss_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        sensor_downsamples[SENSOR_GNSS].dropped_n++;
+                        sensor_downsamples[SENSOR_GNSS].window_n = 0;
                         break;
                     }
 
@@ -366,37 +365,40 @@ void *downsample_main(void *arg) {
                     using the Welford formula to calculate the mean, one pass for each axis
                     mean = mean_(n-1) + (x - mean_(n-1)) / n
                     */
-                    sensor_downsamples[SENSOR_GNSS].mean[0] +=
-                        (gnss_input.latitude - sensor_downsamples[SENSOR_GNSS].mean[0]) /
-                        sensor_downsamples[SENSOR_GNSS].curr_sample_count;
-                    sensor_downsamples[SENSOR_GNSS].mean[1] +=
-                        (gnss_input.longitude - sensor_downsamples[SENSOR_GNSS].mean[1]) /
-                        sensor_downsamples[SENSOR_GNSS].curr_sample_count;
+                    sensor_downsamples[SENSOR_GNSS].out[0] +=
+                        (gnss_input.latitude - sensor_downsamples[SENSOR_GNSS].out[0]) /
+                        sensor_downsamples[SENSOR_GNSS].window_n;
+                    sensor_downsamples[SENSOR_GNSS].out[1] +=
+                        (gnss_input.longitude - sensor_downsamples[SENSOR_GNSS].out[1]) /
+                        sensor_downsamples[SENSOR_GNSS].window_n;
 
-                    if (sensor_downsamples[SENSOR_GNSS].curr_sample_count ==
-                        sensor_downsamples[SENSOR_GNSS].target_sample_count) {
+                    if (sensor_downsamples[SENSOR_GNSS].window_n >= sensor_downsamples[SENSOR_GNSS].target_window_n) {
                         struct sensor_gnss sensor_gnss = {
                             .timestamp = gnss_input.timestamp,
-                            .latitude = sensor_downsamples[SENSOR_GNSS].mean[0],
-                            .longitude = sensor_downsamples[SENSOR_GNSS].mean[1],
+                            .latitude = sensor_downsamples[SENSOR_GNSS].out[0],
+                            .longitude = sensor_downsamples[SENSOR_GNSS].out[1],
                         };
 
-                        if (radio_telem->empty->gnss_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        if (radio_telem->empty_buff->gnss_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
                             inerr("GNSS buffer full, dropping data\n");
+                            sensor_downsamples[SENSOR_GNSS].dropped_n++;
+                            sensor_downsamples[SENSOR_GNSS].window_n = 0;
                             break;
                         }
 
-                        radio_telem->empty->gnss[radio_telem->empty->gnss_n++] = sensor_gnss;
-
-                        sensor_downsamples[SENSOR_GNSS].mean[0] = 0;
-                        sensor_downsamples[SENSOR_GNSS].mean[1] = 0;
-                        sensor_downsamples[SENSOR_GNSS].curr_sample_count = 0;
+                        radio_telem->empty_buff->gnss[radio_telem->empty_buff->gnss_n++] = sensor_gnss;
+                        sensor_downsamples[SENSOR_GNSS].output_n++;
+                        sensor_downsamples[SENSOR_GNSS].out[0] = 0;
+                        sensor_downsamples[SENSOR_GNSS].out[1] = 0;
+                        sensor_downsamples[SENSOR_GNSS].window_n = 0;
                     }
 
                     break;
                 }
                 case SENSOR_ALT: {
-                    if (radio_telem->empty->alt_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                    if (radio_telem->empty_buff->alt_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        sensor_downsamples[SENSOR_ALT].dropped_n++;
+                        sensor_downsamples[SENSOR_ALT].window_n = 0;
                         break;
                     }
 
@@ -406,35 +408,35 @@ void *downsample_main(void *arg) {
                     using the Welford formula to calculate the mean, one pass for each axis
                     mean = mean_(n-1) + (x - mean_(n-1)) / n
                     */
-                    sensor_downsamples[SENSOR_ALT].mean[0] +=
-                        (alt_input.altitude - sensor_downsamples[SENSOR_ALT].mean[0]) /
-                        sensor_downsamples[SENSOR_ALT].curr_sample_count;
+                    sensor_downsamples[SENSOR_ALT].out[0] +=
+                        (alt_input.altitude - sensor_downsamples[SENSOR_ALT].out[0]) /
+                        sensor_downsamples[SENSOR_ALT].window_n;
 
-                    if (sensor_downsamples[SENSOR_ALT].curr_sample_count ==
-                        sensor_downsamples[SENSOR_ALT].target_sample_count) {
+                    if (sensor_downsamples[SENSOR_ALT].window_n >= sensor_downsamples[SENSOR_ALT].target_window_n) {
                         struct fusion_altitude sensor_alt = {
                             .timestamp = alt_input.timestamp,
-                            .altitude = sensor_downsamples[SENSOR_ALT].mean[0],
+                            .altitude = sensor_downsamples[SENSOR_ALT].out[0],
                         };
 
-                        if (radio_telem->empty->alt_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
+                        if (radio_telem->empty_buff->alt_n == CONFIG_INSPACE_DOWNSAMPLING_TARGET_FREQ) {
                             inerr("Altitude buffer full, dropping data\n");
+                            sensor_downsamples[SENSOR_ALT].dropped_n++;
+                            sensor_downsamples[SENSOR_ALT].window_n = 0;
                             break;
                         }
 
-                        radio_telem->empty->alt[radio_telem->empty->alt_n++] = sensor_alt;
-
-                        sensor_downsamples[SENSOR_ALT].mean[0] = 0;
-                        sensor_downsamples[SENSOR_ALT].curr_sample_count = 0;
+                        radio_telem->empty_buff->alt[radio_telem->empty_buff->alt_n++] = sensor_alt;
+                        sensor_downsamples[SENSOR_ALT].output_n++;
+                        sensor_downsamples[SENSOR_ALT].out[0] = 0;
+                        sensor_downsamples[SENSOR_ALT].window_n = 0;
                     }
                     break;
                 }
                 }
             }
-
-            pthread_mutex_unlock(&radio_telem->empty_mux);
         }
     }
+
     publish_error(PROC_ID_DOWNSAMPLE, ERROR_PROCESS_DEAD);
     pthread_exit(0);
 }

--- a/telemetry/src/radio-telem.h
+++ b/telemetry/src/radio-telem.h
@@ -19,10 +19,10 @@ typedef struct {
 } radio_raw_data;
 
 typedef struct {
-    radio_raw_data *full;
-    pthread_mutex_t full_mux;
-    radio_raw_data *empty;
-    pthread_mutex_t empty_mux;
+    radio_raw_data *buff;
+    pthread_mutex_t buff_mux;
+    sem_t swapped;
+    radio_raw_data *empty_buff; /* internal to the downsampler thread */
 } radio_telem_t;
 
 #endif

--- a/telemetry/src/telemetry_main.c
+++ b/telemetry/src/telemetry_main.c
@@ -79,14 +79,14 @@ int main(int argc, char **argv) {
         state_set_flightsubstate(&state, SUBSTATE_UNKNOWN);
     }
 
-    radio_telem.full = &radio_buf1;
-    radio_telem.empty = &radio_buf2;
+    radio_telem.buff = &radio_buf1;
+    radio_telem.empty_buff = &radio_buf2;
 
     memset(&radio_buf1, 0, sizeof(radio_buf1));
     memset(&radio_buf2, 0, sizeof(radio_buf2));
 
-    pthread_mutex_init(&(radio_telem.full_mux), NULL);
-    pthread_mutex_init(&(radio_telem.empty_mux), NULL);
+    pthread_mutex_init(&(radio_telem.buff_mux), NULL);
+    sem_init(&radio_telem.swapped, 0, 0);
 
     /* Start all threads */
     struct fusion_args fusion_thread_args = {.state = &state};

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -30,6 +30,8 @@
 
 #define err_to_ptr(err) ((void *)((err)))
 
+#define TRANSMIT_PERIOD_MS 700
+
 static int transmit(int radio, uint8_t *packet, size_t packet_size);
 static int configure_radio(int fd, struct radio_options const *config);
 
@@ -60,23 +62,20 @@ void *transmit_main(void *arg) {
     /* Transmit forever, regardless of rocket flight state. */
 
     for (;;) {
-        pthread_mutex_lock(&radio_telem->empty_mux);
-        pthread_mutex_lock(&radio_telem->full_mux);
+        struct timespec cycle_start;
+        clock_gettime(CLOCK_MONOTONIC, &cycle_start);
 
-        /* Swap the pointers of the empty and full data */
-        radio_raw_data *temp = radio_telem->empty;
-        radio_telem->empty = radio_telem->full;
-        radio_telem->full = temp;
-
-        /* Reset the new empty buffer's counters */
-        radio_telem->empty->gnss_n = -1;
-        radio_telem->empty->alt_n = -1;
-        radio_telem->empty->mag_n = -1;
-        radio_telem->empty->accel_n = -1;
-        radio_telem->empty->gyro_n = -1;
-
-        /* release the empty mutex, collector can lock it and start collecting again */
-        pthread_mutex_unlock(&radio_telem->empty_mux);
+        pthread_mutex_lock(&radio_telem->buff_mux);
+        radio_raw_data *temp = radio_telem->buff;
+        radio_telem->buff = radio_telem->empty_buff;
+        radio_telem->empty_buff = temp;
+        radio_telem->empty_buff->accel_n = 0;
+        radio_telem->empty_buff->gyro_n = 0;
+        radio_telem->empty_buff->mag_n = 0;
+        radio_telem->empty_buff->gnss_n = 0;
+        radio_telem->empty_buff->alt_n = 0;
+        pthread_mutex_unlock(&radio_telem->buff_mux);
+        sem_post(&radio_telem->swapped);
 
         /* create a new packet buffer */
         uint8_t packet_buffer[PACKET_MAX_SIZE];
@@ -89,17 +88,17 @@ void *transmit_main(void *arg) {
         pkt_hdr_t *header = (pkt_hdr_t *)packet_ptr;
         packet_ptr = pkt_init(packet_ptr, seq_num++, mission_time_ms);
 
-        if (radio_telem->full->gnss_n > 0) {
+        if (radio_telem->buff->gnss_n > 0) {
             header->type_count++;
             blk_hdr_t blk_hdr = {
                 .type = DATA_LAT_LONG,
-                .count = radio_telem->full->gnss_n,
+                .count = radio_telem->buff->gnss_n,
             };
             memcpy(packet_ptr, &blk_hdr, sizeof(blk_hdr));
             packet_ptr += sizeof(blk_hdr);
-            for (int i = 0; i < radio_telem->full->gnss_n; i++) {
+            for (int i = 0; i < radio_telem->buff->gnss_n; i++) {
                 struct coord_blk_t coord_blk;
-                if (orb_gnss_pkt(&radio_telem->full->gnss[i], &coord_blk, header->timestamp)) {
+                if (orb_gnss_pkt(&radio_telem->buff->gnss[i], &coord_blk, header->timestamp)) {
                     inerr("Failed to create GNSS block %d\n", i);
                     continue;
                 }
@@ -109,17 +108,17 @@ void *transmit_main(void *arg) {
             }
         }
 
-        if (radio_telem->full->alt_n > 0) {
+        if (radio_telem->buff->alt_n > 0) {
             header->type_count++;
             blk_hdr_t blk_hdr = {
-                .type = DATA_ALT_LAUNCH,
-                .count = radio_telem->full->alt_n,
+                .type = DATA_ALT_SEA,
+                .count = radio_telem->buff->alt_n,
             };
             memcpy(packet_ptr, &blk_hdr, sizeof(blk_hdr));
             packet_ptr += sizeof(blk_hdr);
-            for (int i = 0; i < radio_telem->full->alt_n; i++) {
+            for (int i = 0; i < radio_telem->buff->alt_n; i++) {
                 struct alt_blk_t alt_blk;
-                if (orb_alt_pkt(&radio_telem->full->alt[i], &alt_blk, header->timestamp)) {
+                if (orb_alt_pkt(&radio_telem->buff->alt[i], &alt_blk, header->timestamp)) {
                     inerr("Failed to create Alt block %d\n", i);
                     continue;
                 }
@@ -128,17 +127,17 @@ void *transmit_main(void *arg) {
             }
         }
 
-        if (radio_telem->full->mag_n > 0) {
+        if (radio_telem->buff->mag_n > 0) {
             header->type_count++;
             blk_hdr_t blk_hdr = {
                 .type = DATA_MAGNETIC,
-                .count = radio_telem->full->mag_n,
+                .count = radio_telem->buff->mag_n,
             };
             memcpy(packet_ptr, &blk_hdr, sizeof(blk_hdr));
             packet_ptr += sizeof(blk_hdr);
-            for (int i = 0; i < radio_telem->full->mag_n; i++) {
+            for (int i = 0; i < radio_telem->buff->mag_n; i++) {
                 struct mag_blk_t mag_blk;
-                if (orb_mag_pkt(&radio_telem->full->mag[i], &mag_blk, header->timestamp)) {
+                if (orb_mag_pkt(&radio_telem->buff->mag[i], &mag_blk, header->timestamp)) {
                     inerr("Failed to create Mag block %d\n", i);
                     continue;
                 }
@@ -147,17 +146,17 @@ void *transmit_main(void *arg) {
             }
         }
 
-        if (radio_telem->full->accel_n > 0) {
+        if (radio_telem->buff->accel_n > 0) {
             header->type_count++;
             blk_hdr_t blk_hdr = {
                 .type = DATA_ACCEL_REL,
-                .count = radio_telem->full->accel_n,
+                .count = radio_telem->buff->accel_n,
             };
             memcpy(packet_ptr, &blk_hdr, sizeof(blk_hdr));
             packet_ptr += sizeof(blk_hdr);
-            for (int i = 0; i < radio_telem->full->accel_n; i++) {
+            for (int i = 0; i < radio_telem->buff->accel_n; i++) {
                 struct accel_blk_t accel_blk;
-                if (orb_accel_pkt(&radio_telem->full->accel[i], &accel_blk, header->timestamp)) {
+                if (orb_accel_pkt(&radio_telem->buff->accel[i], &accel_blk, header->timestamp)) {
                     inerr("Failed to create Accel block %d\n", i);
                     continue;
                 }
@@ -166,17 +165,17 @@ void *transmit_main(void *arg) {
             }
         }
 
-        if (radio_telem->full->gyro_n > 0) {
+        if (radio_telem->buff->gyro_n > 0) {
             header->type_count++;
             blk_hdr_t blk_hdr = {
                 .type = DATA_ANGULAR_VEL,
-                .count = radio_telem->full->gyro_n,
+                .count = radio_telem->buff->gyro_n,
             };
             memcpy(packet_ptr, &blk_hdr, sizeof(blk_hdr));
             packet_ptr += sizeof(blk_hdr);
-            for (int i = 0; i < radio_telem->full->gyro_n; i++) {
+            for (int i = 0; i < radio_telem->buff->gyro_n; i++) {
                 struct ang_vel_blk_t ang_vel_blk;
-                if (orb_ang_vel_pkt(&radio_telem->full->gyro[i], &ang_vel_blk, header->timestamp)) {
+                if (orb_ang_vel_pkt(&radio_telem->buff->gyro[i], &ang_vel_blk, header->timestamp)) {
                     inerr("Failed to create Ang vel block %d\n", i);
                     continue;
                 }
@@ -185,22 +184,34 @@ void *transmit_main(void *arg) {
             }
         }
 
-        pthread_mutex_unlock(&radio_telem->full_mux);
         size_t packet_size = packet_ptr - packet_buffer;
         if (packet_size > PACKET_MAX_SIZE) {
-            /* if the packet size is too large we are cooked, this should never happen if the downsampling variable is
-             * set correctly */
             inerr("Packet size is too large: %zu\n", packet_size);
-            continue;
-        } else if (packet_size == sizeof(pkt_hdr_t)) {
-            inerr("Packet does not contain any data\n");
-            /* this sleep is needed to avoid priority inversion between the 2 threads, this is a problem I didn't find a
-             * good soluition to */
-            sleep(1);
-            continue;
+        } else if (packet_size > sizeof(pkt_hdr_t)) {
+            ininfo("Transmitting packet #%u of size %zu bytes. Accel: %d, Gyro: %d, Mag: %d, GNSS: %d, Alt: %d\n",
+                   header->packet_num, packet_size, radio_telem->buff->accel_n, radio_telem->buff->gyro_n,
+                   radio_telem->buff->mag_n, radio_telem->buff->gnss_n, radio_telem->buff->alt_n);
+            err = transmit(radio, packet_buffer, packet_size);
+            if (err < 0) {
+                inerr("Error transmitting packet: %d\n", -err);
+            }
         }
-        ininfo("Packet size: %zu\n", packet_size);
-        transmit(radio, packet_buffer, packet_size);
+
+        /* for the sake of making the dynamic rate adjustment work, we need at least one static thing as an anchor, imo
+         * the choice should be transmission time */
+        struct timespec cycle_end;
+        clock_gettime(CLOCK_MONOTONIC, &cycle_end);
+        long elapsed_ms =
+            (cycle_end.tv_sec - cycle_start.tv_sec) * 1000 + (cycle_end.tv_nsec - cycle_start.tv_nsec) / 1000000;
+        ininfo("Transmission cycle time: %ld ms\n", elapsed_ms);
+        long remaining_ms = TRANSMIT_PERIOD_MS - elapsed_ms;
+        if (remaining_ms > 0) {
+            struct timespec sleep_time = {
+                .tv_sec = remaining_ms / 1000,
+                .tv_nsec = (remaining_ms % 1000) * 1000000,
+            };
+            nanosleep(&sleep_time, NULL);
+        }
     }
 
 err_cleanup:

--- a/telemetry/src/transmission/transmit.c
+++ b/telemetry/src/transmission/transmit.c
@@ -1,9 +1,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <math.h>
+#include <poll.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <time.h>
 #include <unistd.h>
 
 #if defined(CONFIG_LPWAN_RN2XX3)
@@ -29,8 +32,12 @@
 /* Cast an error to a void pointer */
 
 #define err_to_ptr(err) ((void *)((err)))
-
 #define TRANSMIT_PERIOD_MS 700
+
+enum status_topics_e {
+    STATUS_TOPIC = 0,
+    ERROR_TOPIC = 1,
+};
 
 static int transmit(int radio, uint8_t *packet, size_t packet_size);
 static int configure_radio(int fd, struct radio_options const *config);
@@ -42,6 +49,17 @@ void *transmit_main(void *arg) {
     struct transmit_args *unpacked_args = (struct transmit_args *)arg;
     radio_telem_t *radio_telem = unpacked_args->radio_telem;
     uint32_t seq_num = 0;
+
+    ORB_DECLARE(status_message);
+    ORB_DECLARE(error_message);
+    const struct orb_metadata *status_metas[] = {
+        [STATUS_TOPIC] = ORB_ID(status_message),
+        [ERROR_TOPIC] = ORB_ID(error_message),
+    };
+    struct pollfd status_fds[] = {
+        [STATUS_TOPIC] = {.fd = -1, .events = POLLIN, .revents = 0},
+        [ERROR_TOPIC] = {.fd = -1, .events = POLLIN, .revents = 0},
+    };
 
     ininfo("Transmit thread started.\n");
 
@@ -57,6 +75,14 @@ void *transmit_main(void *arg) {
         /* Error will have been reported in configure_rn2483 where we can say which
          * config failed in particular */
         goto err_cleanup;
+    }
+
+    for (int i = 0; i < sizeof(status_fds) / sizeof(status_fds[0]); i++) {
+        status_fds[i].fd = orb_subscribe(status_metas[i]);
+        if (status_fds[i].fd < 0) {
+            err = errno;
+            inerr("Failed to subscribe to '%s': %d\n", status_metas[i]->o_name, err);
+        }
     }
 
     /* Transmit forever, regardless of rocket flight state. */
@@ -87,6 +113,56 @@ void *transmit_main(void *arg) {
         uint32_t mission_time_ms = current_time.tv_sec * 1000 + current_time.tv_nsec / 1000000;
         pkt_hdr_t *header = (pkt_hdr_t *)packet_ptr;
         packet_ptr = pkt_init(packet_ptr, seq_num++, mission_time_ms);
+
+        err = poll(status_fds, sizeof(status_fds) / sizeof(status_fds[0]), 0);
+        if (err < 0) {
+            inwarn("Status poll failed: %d\n", errno);
+            continue;
+        }
+
+        if (status_fds[STATUS_TOPIC].revents & POLLIN) {
+            struct status_message latest_status;
+            err = orb_copy(ORB_ID(status_message), status_fds[STATUS_TOPIC].fd, &latest_status);
+            if (err < 0) {
+                inwarn("Failed to read status message: %d\n", errno);
+            } else {
+                struct status_blk_t status_blk;
+                err = orb_status_pkt(&latest_status, &status_blk, header->timestamp);
+                if (err == 0) {
+                    blk_hdr_t status_hdr = {.type = DATA_STATUS, .count = 1};
+                    header->type_count++;
+                    memcpy(packet_ptr, &status_hdr, sizeof(status_hdr));
+                    packet_ptr += sizeof(status_hdr);
+                    memcpy(packet_ptr, &status_blk, sizeof(status_blk));
+                    packet_ptr += sizeof(status_blk);
+                } else {
+                    inerr("Failed to append status block: %d\n", EINVAL);
+                }
+            }
+        }
+        status_fds[STATUS_TOPIC].revents = 0;
+
+        if (status_fds[ERROR_TOPIC].revents & POLLIN) {
+            struct error_message latest_error;
+            err = orb_copy(ORB_ID(error_message), status_fds[ERROR_TOPIC].fd, &latest_error);
+            if (err < 0) {
+                inwarn("Failed to read error message: %d\n", errno);
+            } else {
+                struct error_blk_t error_blk;
+                err = orb_error_pkt(&latest_error, &error_blk, header->timestamp);
+                if (err == 0) {
+                    blk_hdr_t error_hdr = {.type = DATA_ERROR, .count = 1};
+                    header->type_count++;
+                    memcpy(packet_ptr, &error_hdr, sizeof(error_hdr));
+                    packet_ptr += sizeof(error_hdr);
+                    memcpy(packet_ptr, &error_blk, sizeof(error_blk));
+                    packet_ptr += sizeof(error_blk);
+                } else {
+                    inerr("Failed to append error block: %d\n", EINVAL);
+                }
+            }
+        }
+        status_fds[ERROR_TOPIC].revents = 0;
 
         if (radio_telem->buff->gnss_n > 0) {
             header->type_count++;


### PR DESCRIPTION
The previous implementation had inconsistent results in telemetry packaging due to every aspect of the system being dynamic, something I didn't realize at first.

A dynamic rate adjustment, dynamic packet size and dynamic transmission time. The combination of 3 created inconsistencies and thread priority inversion. To fix the issue the transmission time has been hardcoded to be min 700ms (can prob go lower to like 600, this is for after). 

The result is that downsampling rates now dynamically adjust themselves as they should in a consistent manner. 

Switched to a semaphore as indicator on whether the swapping has been done for clarity purposes

Additionally there has been some naming changes for better clarity.